### PR TITLE
Fix for send location

### DIFF
--- a/app/controller/NavigationController.js
+++ b/app/controller/NavigationController.js
@@ -49,7 +49,7 @@ SDL.NavigationController = Em.Object.create(
      * @param {Object} request
      */
     sendLocation: function(request) {
-      this.model.push(
+      this.model.LocationDetails.push(
         {
           coordinate: {
             latitudeDegrees: request.params.latitudeDegrees,


### PR DESCRIPTION
This line before the fix was giving the error

NavigationController.js:52 Uncaught TypeError: this.model.push is not a function

This fix now pushes location to the LocationDetails array of the navigation model.