### PR TITLE
Support Navi.SetVideoConfig request/response

### DIFF
--- a/app/controller/sdl/RPCController.js
+++ b/app/controller/sdl/RPCController.js
@@ -781,6 +781,46 @@ SDL.RPCController = Em.Object.create(
           return this.resultStruct;
         },
         /**
+         * Validate method for request Navigation.SetVideoConfig
+         *
+         * @param {Object}
+         *            params
+         */
+        SetVideoConfig: function(params) {
+          if (params == null) {
+            this.resultStruct = {
+              'resultCode': SDL.SDLModel.data.resultCode.INVALID_DATA,
+              'resultMessage': 'Parameter \'params\' does not exist!'
+            };
+            return this.resultStruct;
+          }
+          if (params.config == null) {
+            this.resultStruct = {
+              'resultCode': SDL.SDLModel.data.resultCode.INVALID_DATA,
+              'resultMessage': 'Parameter \'config\' does not exist!'
+            };
+            return this.resultStruct;
+          }
+          if (params.appID == null) {
+            this.resultStruct = {
+              'resultCode': SDL.SDLModel.data.resultCode.INVALID_DATA,
+              'resultMessage': 'Parameter \'appID\' does not exist!'
+            };
+            return this.resultStruct;
+          }
+          if (typeof params.appID != 'number') {
+            this.resultStruct = {
+              'resultCode': SDL.SDLModel.data.resultCode.INVALID_DATA,
+              'resultMessage': 'Wrong type of parameter \'appID\'!'
+            };
+            return this.resultStruct;
+          }
+          this.resultStruct = {
+            'resultCode': SDL.SDLModel.data.resultCode.SUCCESS
+          };
+          return this.resultStruct;
+        },
+        /**
          * Validate method for request StartStream
          *
          * @param {Object}

--- a/ffw/NavigationRPC.js
+++ b/ffw/NavigationRPC.js
@@ -315,6 +315,43 @@ FFW.Navigation = FFW.RPCObserver.create(
             );
             break;
           }
+          case 'Navigation.SetVideoConfig':
+          {
+            var rejectedParams = [];
+            if ('protocol' in request.params.config) {
+              if (request.params.config.protocol != 'RAW') {
+                Em.Logger.log('FFW.' + request.method + ' rejects protocol: '
+                              + request.params.config.protocol);
+                rejectedParams.push('protocol');
+              }
+            }
+            if ('codec' in request.params.config) {
+              if (request.params.config.codec != 'H264') {
+                Em.Logger.log('FFW.' + request.method + ' rejects codec: '
+                              + request.params.config.codec);
+                rejectedParams.push('codec');
+              }
+            }
+            if (rejectedParams.length > 0) {
+              var JSONMessage = {
+                'jsonrpc': '2.0',
+                'id': request.id,
+                'result': {
+                  'code': SDL.SDLModel.data.resultCode.REJECTED,
+                  'method': request.method,
+                  'rejectedParams': rejectedParams
+                }
+              };
+              this.client.send(JSONMessage);
+            } else {
+              this.sendNavigationResult(
+                SDL.SDLModel.data.resultCode.SUCCESS,
+                request.id,
+                request.method
+              );
+            }
+            break;
+          }
           case 'Navigation.StartStream':
           {
             var text = 'Would you like to start Video stream?';


### PR DESCRIPTION
Latest HMI API includes SetVideoConfig RPC so HMIs need to support it.
This PR adds minimum support of the RPC; accepts "H264" codec and "RAW" protocol only, no verification of "width" and "height".