### PR TITLE
Fix greyed out applications list on HMI launch

### DIFF
--- a/app/model/sdl/RModel.js
+++ b/app/model/sdl/RModel.js
@@ -136,6 +136,12 @@ SDL.RModel = SDL.SDLModel.extend({
       applicationType = 2;
     }
 
+    if (this.driverDevice && this.driverDeviceInfo == null) {
+      if (params.deviceInfo) {
+        this.set('driverDeviceInfo', params.deviceInfo);
+      }
+    }
+
     SDL.SDLController.registerApplication(params, applicationType);
 
     if (SDL.SDLModel.data.unRegisteredApps.indexOf(params.appID) >= 0) {


### PR DESCRIPTION
There was a problem that when HMI does not receive from SDL `UpdateDeviceList`, it does not set info
about drivers device so all devices, that will be connected after that will be treated as non-driver devices and will be displayed as inactive.

To solve that problem was added driver info init on receiving `onAppRegistered` notification because it also contains information about application device.