### PR TITLE
Fix Uncaught TypeError when receiving SendLocation

### DIFF
--- a/app/controller/NavigationController.js
+++ b/app/controller/NavigationController.js
@@ -421,7 +421,7 @@ SDL.NavigationController = Em.Object.create(
     timerHandle: null,
 
     initialize: function() {
-      if (!this.isInitialized && SDL.States.navigation.active) {
+      if (!this.isInitialized) {
         this.isInitialized = true;
       } else {
         return false;

--- a/ffw/NavigationRPC.js
+++ b/ffw/NavigationRPC.js
@@ -158,7 +158,11 @@ FFW.Navigation = FFW.RPCObserver.create(
         switch (request.method) {
           case 'Navigation.IsReady':
           {
-            Em.Logger.log('FFW.' + request.method + 'Response');
+            Em.Logger.log('FFW.' + request.method + ' Response');
+            if (!SDL.NavigationController.isInitialized) {
+              SDL.NavigationController.initialize();
+            }
+            this.set('isReady', SDL.NavigationController.isInitialized);
             // send repsonse
             var JSONMessage = {
               'jsonrpc': '2.0',


### PR DESCRIPTION
There was a problem that `NavigationController` could be not inited before receiving `SendLocation` and this
lead to reported error.

There was added initialize of NavigationController on requesting `Navigation.IsReady` so if navigation module
is active, then it will be inited on `Navi.isReady` request and result of initialization will be transfered in isReady
response.