### PR TITLE
Improve vehicle data parameters editor interface

### DIFF
--- a/app/AppViews.js
+++ b/app/AppViews.js
@@ -70,6 +70,7 @@ SDL.AppViews = Em.ContainerView.extend(
       SDL.AudioPassThruPopUp,
       SDL.VRPopUp,
       SDL.VehicleInfo,
+      SDL.EditVehicleDataView,
       SDL.TBTClientStateView,
       SDL.DriverDistraction,
       SDL.ExitApp,

--- a/app/controller/sdl/Abstract/Controller.js
+++ b/app/controller/sdl/Abstract/Controller.js
@@ -368,32 +368,25 @@ SDL.SDLController = Em.Object.extend(
       return 0;
     },
     /**
+     * Filters object properties using predicate and returns
+     * object where properties are equal to predicate
+     */
+    filterObjectByPredicate: function(obj, predicate) {
+      var result = {}, key;
+
+      for (key in obj) {
+        if (obj.hasOwnProperty(key) && key == predicate) {
+          result[key] = obj[key];
+        }
+      }
+
+      return result;
+    },
+    /**
      * vehicleDataChange button handler on VehicleInfo View
      */
     vehicleDataChange: function() {
-      SDL.VehicleInfo.vehicleDataCodeEditor.activate(
-        function(data) {
-          var params = {};
-          var parsedData = JSON.parse(data);
-          for (var i in parsedData) {
-            if (SDL.SDLController.compareObjects(
-                SDL.SDLVehicleInfoModel.vehicleData[i],
-                parsedData[i]
-              )
-            ) {
-              params[i] = parsedData[i];
-            }
-          }
-          SDL.SDLVehicleInfoModel.vehicleData = parsedData;
-          if (params) {
-            FFW.VehicleInfo.OnVehicleData(params);
-          }
-        }
-      );
-      SDL.VehicleInfo.vehicleDataCodeEditor.editor.set(
-        'code',
-        JSON.stringify(SDL.SDLVehicleInfoModel.vehicleData, null, 2)
-      );
+      SDL.EditVehicleDataView.toggleActivity();
     },
     /**
      * Notify SDLCore that HMI is ready and all components are registered

--- a/app/controller/sdl/EditVehicleDataController.js
+++ b/app/controller/sdl/EditVehicleDataController.js
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2017, Ford Motor Company All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met: ·
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer. · Redistributions in binary
+ * form must reproduce the above copyright notice, this list of conditions and
+ * the following disclaimer in the documentation and/or other materials provided
+ * with the distribution. · Neither the name of the Ford Motor Company nor the
+ * names of its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * @name SDL.EditVehicleDataController
+ * @desc Edit vehicle data module logic
+ * @category Controller
+ * @filesource app/controller/sdl/EditVehicleDataController.js
+ * @version 1.0
+ */
+
+SDL.EditVehicleDataController = Em.Object.create({
+
+  /**
+   * Model binding
+   */
+  modelBinding: 'SDL.SDLVehicleInfoModel',
+
+  /**
+   * Path to currently active parameter in vehicleData map
+   */
+  currentParameterPath: '.',
+
+  /**
+   * Name of currently active parameter in vehicleData map
+   */
+  currentParameterName: '',
+
+  /**
+   * Value of param to edit
+   */
+  paramValue: null,
+
+  /**
+   * Type of param value to edit
+   */
+  paramValueType: '',
+
+  /**
+   * Flag to display edit param view or not
+   */
+  isParamEditing: false,
+
+  /**
+   * Event when user clicks edit parameter button
+   */
+  onParamButtonClick: function(element) {
+    var key = element.itemID;
+    this.set('currentParameterName', key);
+
+    var value = this.getParameterValueFromMap(key);
+    var valueType = typeof value;
+
+    switch (typeof value) {
+      case 'boolean': {
+         this.set('paramValue', value.toString());
+         break;
+      }
+      case 'number':
+      case 'string': {
+         this.set('paramValue', value);
+         break;
+      }
+      default: {
+        this.set('paramValue', '');
+      }
+    }
+
+    this.set('paramValueType', valueType);
+    this.toggleProperty('isParamEditing');
+  },
+
+  /**
+   * Event when user clicks arrow button
+   */
+  onArrowButtonClick: function(element) {
+    var key = element.itemID;
+
+    this.set('currentParameterPath',
+      this.get('currentParameterPath') + '/' + key
+    );
+  },
+
+  /**
+   * Event when user clicks back button
+   */
+  onBackButtonClick: function() {
+    if (this.isParamEditing) {
+      this.cancelParamChanges();
+      return;
+    }
+    if (this.currentParameterPath != '.') {
+      this.gotoUpperLevelMap();
+      return;
+    }
+    SDL.EditVehicleDataView.toggleActivity();
+  },
+
+  /**
+   * Gets parameter value from map using path and key
+   */
+  getParameterValueFromMap: function(key) {
+    var path = this.currentParameterPath.split('/');
+    var target;
+    for (var i = 0; i < path.length; ++i) {
+      if (path[i] == '.') {
+        target = this.model.vehicleData;
+      } else {
+        target = target[path[i]];
+      }
+    }
+    return target[key];
+  },
+
+  /**
+   * Sets parameter value in map using path and key
+   */
+  setParameterValueForMap: function(key, value) {
+    var path = this.currentParameterPath.split('/');
+    path.push(key);
+    var target = '';
+    for (var i = 0; i < path.length; ++i) {
+      if (path[i] != '.') {
+        target += '.' + path[i];
+      }
+    }
+    var oldValue = this.getParameterValueFromMap(key);
+    var newValue;
+    switch (this.paramValueType) {
+      case 'boolean': {
+        newValue = value == 'true';
+        break;
+      }
+      case 'number': {
+        newValue = parseFloat(value);
+        break;
+      }
+      default: {
+        newValue = value;
+      }
+    }
+
+    this.model.set('vehicleData' + target, newValue);
+    if (newValue != oldValue) {
+      this.notifyAboutParamChanges();
+    }
+  },
+
+  /**
+   * Sends notification about changing of currently edited parameter
+   */
+  notifyAboutParamChanges: function() {
+    var path = this.currentParameterPath.split('/');
+    var rootKeyName;
+    if (path.length == 1) {
+      rootKeyName = this.currentParameterName;
+    } else {
+      rootKeyName = path[1];
+    }
+    var rootParamValue = SDL.SDLController.filterObjectByPredicate(
+      this.model.vehicleData, rootKeyName
+    );
+    FFW.VehicleInfo.OnVehicleData(rootParamValue);
+  },
+
+  /**
+   * Applies new parameter value for currently selected key
+   */
+  applyParamChanges: function() {
+    this.setParameterValueForMap(
+      this.currentParameterName, this.paramValue
+    );
+    this.set('currentParameterName', '');
+    this.toggleProperty('isParamEditing');
+  },
+
+  /**
+   * Exit from current parameter editor
+   */
+  cancelParamChanges: function() {
+    this.set('currentParameterName', '');
+    this.toggleProperty('isParamEditing');
+  },
+
+  /**
+   * Goes back to parent map object
+   */
+  gotoUpperLevelMap: function() {
+    var path = this.currentParameterPath.split('/');
+    if (path.length > 1) path.pop();
+
+    this.set('currentParameterPath', path.join('/'));
+  }
+
+}
+);

--- a/app/view/home/controlButtons.js
+++ b/app/view/home/controlButtons.js
@@ -217,7 +217,9 @@ SDL.ControlButtons = Em.ContainerView.create({
         action: function() {
 
           // this._super();
-          SDL.VehicleInfo.toggleActivity();
+          if (!SDL.EditVehicleDataView.active) {
+            SDL.VehicleInfo.toggleActivity();
+          }
         },
         templateName: 'text'
       }

--- a/app/view/sdl/EditVehicleDataView.js
+++ b/app/view/sdl/EditVehicleDataView.js
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2017, Ford Motor Company All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met: ·
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer. · Redistributions in binary
+ * form must reproduce the above copyright notice, this list of conditions and
+ * the following disclaimer in the documentation and/or other materials provided
+ * with the distribution. · Neither the name of the Ford Motor Company nor the
+ * names of its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * @name SDL.EditVehicleDataView
+ * @desc Visual vehicle data editor representation
+ * @category View
+ * @filesource app/view/sdl/EditVehicleDataView.js
+ * @version 1.0
+ */
+
+SDL.EditVehicleDataView = Em.ContainerView.create(
+  {
+    elementId: 'EditVehicleData',
+    classNames: 'EditVehicleData',
+    classNameBindings: [
+      'active'
+    ],
+    childViews: [
+      'backButton',
+      'vehicleEditInfoLabel',
+      'vehicleDataList',
+      'editParameterView'
+    ],
+    /**
+     * Property indicates the activity state of VehicleInfo PopUp
+     */
+    active: false,
+    /**
+     * Back button view
+     */
+    backButton: SDL.Button.extend(
+      {
+        classNames: [
+          'backButton'
+        ],
+        target: 'SDL.EditVehicleDataController',
+        action: 'onBackButtonClick',
+        icon: 'images/media/ico_back.png',
+        onDown: false
+      }
+    ),
+    /**
+     * Title of EditVehicleDataView PopUp view
+     */
+    vehicleEditInfoLabel: SDL.Label.extend(
+      {
+        elementId: 'vehicleEditInfoLabel',
+        classNames: 'vehicleEditInfoLabel',
+        content: 'Main vehicle data parameters',
+        getParameterPath: function() {
+          var param = SDL.EditVehicleDataController.currentParameterName;
+          if (param == '') {
+            this.set('content', 'Edit vehicle data parameters');
+            return;
+          }
+          this.set('content', 'Parameter: ' + param);
+        }.observes('SDL.EditVehicleDataController.currentParameterName')
+      }
+    ),
+    /**
+     * List of vehicle data items
+     */
+    vehicleDataList: SDL.List.extend(
+      {
+        classNames: [
+          'vdList'
+        ],
+        classNameBindings: [
+          'SDL.EditVehicleDataController.isParamEditing:inactive_state:active_state'
+        ],
+        elementId: 'vdList',
+        itemsOnPage: 5,
+        itemsBinding: 'this.itemGenerator',
+        getActiveObject: function(rootObj, path) {
+          var keys = path.split('/');
+          var target;
+          for (var i = 0; i < keys.length; ++i) {
+            if (keys[i] == '.') {
+              target = rootObj;
+            } else {
+              target = target[keys[i]];
+            }
+          }
+          return target;
+        },
+        getSortedProperties: function(object) {
+          var properties = [];
+          for (var key in object) {
+            if (object.hasOwnProperty(key)) {
+              properties.push(key);
+            }
+          }
+          properties.sort();
+          return properties;
+        },
+        itemGenerator: function() {
+          var activeObject =
+            this.getActiveObject(
+              SDL.SDLVehicleInfoModel.vehicleData,
+              SDL.EditVehicleDataController.currentParameterPath
+            );
+          var properties = this.getSortedProperties(activeObject);
+          var items = [];
+          for (var i = 0; i < properties.length; ++i) {
+            var key = properties[i];
+            var value = activeObject[key];
+            var isComplex =
+              typeof value == 'object' || typeof value == 'array';
+            items.push(
+            {
+              type: SDL.Button,
+              params: {
+                itemID: key,
+                className: 'button',
+                text: 'Parameter "' + key + '"' +
+                  (!isComplex ? ' = ' + value : ''),
+                disabled: false,
+                onDown: false,
+                templateName: 'text',
+                templateName: (isComplex ? 'arrow' : 'text'),
+                action: (isComplex ? 'onArrowButtonClick' :
+                  'onParamButtonClick'),
+                target: 'SDL.EditVehicleDataController'
+              }
+            });
+          }
+          return items;
+        }.property('SDL.SDLVehicleInfoModel.vehicleData',
+          'SDL.EditVehicleDataController.isParamEditing',
+          'SDL.EditVehicleDataController.currentParameterPath')
+      }
+    ),
+    /**
+     * Edit parameter view
+     */
+    editParameterView: Em.ContainerView.create({
+      elementId: 'editParameterView',
+      classNames: 'editParameterView',
+      classNameBindings: [
+        'SDL.EditVehicleDataController.isParamEditing:active_state:inactive_state'
+      ],
+      childViews: [
+        'editParamInput',
+        'applyChangesButton'
+      ],
+      /**
+       * Input for speed value changes
+       */
+      editParamInput: Ember.TextField.extend(
+        {
+          elementId: 'editParamInput',
+          classNames: 'editParamInput',
+          valueBinding: 'SDL.EditVehicleDataController.paramValue',
+          keyUp: function(event, view) {
+            if (event.key == 'Enter') {
+              SDL.EditVehicleDataController.applyParamChanges();
+            }
+          }
+        }
+      ),
+      /**
+       * Button to apply param changes
+       */
+      applyChangesButton: SDL.Button.extend(
+        {
+          elementId: 'applyChangesButton',
+          classNames: 'button applyChangesButton',
+          action: 'applyParamChanges',
+          target: 'SDL.EditVehicleDataController',
+          text: 'Apply',
+          enabled: false,
+          onDown: false
+        }
+      )
+    }),
+    /**
+     * Trigger function that activates and deactivates VehicleInfo PopUp
+     */
+    toggleActivity: function() {
+      this.set('active', !this.active);
+    }
+  }
+);

--- a/app/view/sdl/VehicleInfoView.js
+++ b/app/view/sdl/VehicleInfoView.js
@@ -74,11 +74,7 @@ SDL.VehicleInfo = Em.ContainerView.create(
       {
         elementId: 'odometrInput',
         classNames: 'odometrInput',
-        keyUp: function(event, view) {
-          if (event.which == 13) {
-            SDL.SDLVehicleInfoModel.set('odometrInput', parseInt(this.value));
-          }
-        }
+        valueBinding: 'SDL.SDLVehicleInfoModel.odometrInput'
       }
     ),
     /**
@@ -206,13 +202,7 @@ SDL.VehicleInfo = Em.ContainerView.create(
       {
         elementId: 'fuelLevelInput',
         classNames: 'fuelLevelInput',
-        keyUp: function(event, view) {
-          if (event.which == 13) {
-            SDL.SDLVehicleInfoModel.set(
-              'fuelLevelInput', parseFloat(this.value)
-            );
-          }
-        }
+        valueBinding: 'SDL.SDLVehicleInfoModel.fuelLevelInput'
       }
     ),
     /**
@@ -222,11 +212,7 @@ SDL.VehicleInfo = Em.ContainerView.create(
       {
         elementId: 'speedInput',
         classNames: 'speedInput',
-        keyUp: function(event, view) {
-          if (event.which == 13) {
-            SDL.SDLVehicleInfoModel.set('speedInput', parseFloat(this.value));
-          }
-        }
+        valueBinding: 'SDL.SDLVehicleInfoModel.speedInput'
       }
     ),
     /**

--- a/css/sdl.css
+++ b/css/sdl.css
@@ -559,8 +559,8 @@
 }
 
 #exitAppView, #tbtClientStateView,
-#VehicleInfo, #systemRequestView,
-#PrimaryDevice {
+#VehicleInfo, #EditVehicleData,
+#systemRequestView, #PrimaryDevice {
     opacity: 0;
     left: 50px;
     width: 700px;
@@ -596,6 +596,7 @@
 #systemRequestView.active,
 #tbtClientStateView.active,
 #VehicleInfo.active,
+#EditVehicleData.active,
 #PrimaryDevice.active {
     opacity: 1;
     display: block;
@@ -638,6 +639,65 @@
 #VehicleInfo .fuelLevelLabel {
     width: 140px;
     left: 271px;
+}
+
+#EditVehicleData .backButton {
+    top: 10px;
+    left: 15px;
+    width: 48px;
+    height: 48px;
+    border: 1px solid #333;
+    border-radius: 2px;
+}
+
+#EditVehicleData .backButton .ico {
+    margin-top: 13px;
+    margin-left: 8px;
+}
+
+#EditVehicleData .vehicleEditInfoLabel {
+    top: 10px;
+    left: 100px;
+    width: 520px;
+    height: 20px;
+    padding: 15px;
+    background: #393939;
+}
+
+#EditVehicleData .vdList {
+    top: 75px;
+    left: 100px;
+    height: 251px;
+    width: 550px;
+    white-space: nowrap;
+}
+
+#EditVehicleData .list-content {
+    width: 500px;
+}
+
+#EditVehicleData .editParameterView {
+    width: 550px;
+    height: 200px;
+    left: 100px;
+    top: 75px;
+}
+
+#EditVehicleData .editParamInput {
+    left: 0px !important;
+    width: 530px !important;
+    top: 0px !important;
+}
+
+#EditVehicleData .applyChangesButton
+ {
+    line-height: 48px;
+    padding-left: 37px;
+    padding-right: 5px;
+    font-size: 26px;
+    width: 100px;
+    height: 48px;
+    top: 60px;
 }
 
 #PrimaryDevice .chooseLabel {
@@ -774,6 +834,7 @@
 #VehicleInfo .odometrInput,
 #VehicleInfo .speedInput,
 #VehicleInfo .fuelLevelInput,
+#EditVehicleData .editParamInput,
 #systemRequestView .urlsInput,
 #systemRequestView .policyAppIdInput,
 #systemRequestView .fileNameInput,
@@ -868,7 +929,7 @@
 }
 
 #VehicleInfo .ecu1 {
-    top: 233px;
+    top: 230px;
     width: 80px;
     left: 65px;
     height: 20px;
@@ -876,7 +937,7 @@
 }
 
 #VehicleInfo .ecu2 {
-    top: 265px;
+    top: 260px;
     width: 80px;
     left: 65px;
     height: 20px;
@@ -884,7 +945,7 @@
 }
 
 #VehicleInfo .ecu1Data {
-    top: 233px;
+    top: 230px;
     width: 155px;
     left: 155px;
     height: 20px;
@@ -892,7 +953,7 @@
 }
 
 #VehicleInfo .ecu2Data {
-    top: 265px;
+    top: 260px;
     width: 155px;
     left: 155px;
     height: 20px;

--- a/index.html
+++ b/index.html
@@ -144,6 +144,8 @@
 
 <script type="text/javascript"
         src="app/controller/sdl/FuncSwitcher.js"></script>
+<script type="text/javascript"
+        src="app/controller/sdl/EditVehicleDataController.js"></script>
 
 <!-- Mixins -->
 <script type="text/javascript" src="app/mixins/PresetEvents.js"></script>
@@ -247,6 +249,7 @@
 <script type="text/javascript"
         src="app/view/sdl/AudioPassThruPopUp.js"></script>
 <script type="text/javascript" src="app/view/sdl/VRPopUp.js"></script>
+<script type="text/javascript" src="app/view/sdl/EditVehicleDataView.js"></script>
 <script type="text/javascript" src="app/view/sdl/VehicleInfoView.js"></script>
 <script type="text/javascript" src="app/view/sdl/VRHelpListView.js"></script>
 <script type="text/javascript"


### PR DESCRIPTION
Default code editor for vehicle data parameters was replaced with more user-friendly custom editor.
In this commit:
- Added `EditVehicleDataView` for displaying editor windows
- Added `EditVehicleDataController` for implementing logic of `EditVehicleDataView` and controlling `SDLVehicleInfoModel`
- Minor updates in css - fixed some controls position in view
- Fixed closing of `VehicleInfo` view when `EditVehicleDataView` is opened

### NOTE
This is a duplicate of PR #31 but for this branch