### PR TITLE
Fix SubscribeVehicleData/UnsubscribeVehicleData response

### DIFF
--- a/app/model/sdl/Abstract/Model.js
+++ b/app/model/sdl/Abstract/Model.js
@@ -60,13 +60,6 @@ SDL.SDLModel = Em.Object.extend({
 
   },
 
-  /**
-   * List of subscribed data on VehicleInfo model
-   *
-   * @type {Object}
-   */
-  subscribedData: {},
-
   applicationStatusBar: '',
 
   updateStatusBar: function() {

--- a/app/model/sdl/MediaModel.js
+++ b/app/model/sdl/MediaModel.js
@@ -37,16 +37,6 @@ SDL.SDLMediaModel = SDL.ABSAppModel.extend({
 
     this._super();
 
-    var subscribeVIData = {};
-
-    for (var key in SDL.SDLVehicleInfoModel.vehicleData) {
-      if (key != 'externalTemperature') {
-        subscribeVIData[key] = false;
-      }
-    }
-
-    this.set('subscribedData', subscribeVIData);
-
     // init properties here
     this.set('appInfo', Em.Object.create({
           field1: '<field1>',

--- a/app/model/sdl/NonMediaModel.js
+++ b/app/model/sdl/NonMediaModel.js
@@ -37,16 +37,6 @@ SDL.SDLNonMediaModel = SDL.ABSAppModel.extend({
 
     this._super();
 
-    var subscribeVIData = {};
-
-    for (var key in SDL.SDLVehicleInfoModel.vehicleData) {
-      if (key != 'externalTemperature') {
-        subscribeVIData[key] = false;
-      }
-    }
-
-    this.set('subscribedData', subscribeVIData);
-
     // init properties here
     this.set('appInfo', Em.Object.create({
           field1: '<field1>',


### PR DESCRIPTION
There was a problem that HMI keeps subscription status of applications on `SubscribeVehicleData/UnsubscribeVehicleData` requests is coming. However this is an SDL responsibility
to manage with subscriptions.

In this commit was updated HMI logic to provide only list of available vehicle data and just check requested data using it. All logic related to subscriptions was removed.