### PR TITLE
Fix SubscribeVehicleData/UnsubscribeVehicleData response

### DIFF
--- a/app/model/sdl/Abstract/Model.js
+++ b/app/model/sdl/Abstract/Model.js
@@ -60,13 +60,6 @@ SDL.SDLModel = Em.Object.extend({
 
   },
 
-  /**
-   * List of subscribed data on VehicleInfo model
-   *
-   * @type {Object}
-   */
-  subscribedData: {},
-
   applicationStatusBar: '',
 
   updateStatusBar: function() {

--- a/app/model/sdl/MediaModel.js
+++ b/app/model/sdl/MediaModel.js
@@ -37,16 +37,6 @@ SDL.SDLMediaModel = SDL.ABSAppModel.extend({
 
     this._super();
 
-    var subscribeVIData = {};
-
-    for (var key in SDL.SDLVehicleInfoModel.vehicleData) {
-      if (key != 'externalTemperature') {
-        subscribeVIData[key] = false;
-      }
-    }
-
-    this.set('subscribedData', subscribeVIData);
-
     // init properties here
     this.set('appInfo', Em.Object.create({
           field1: '<field1>',

--- a/app/model/sdl/NonMediaModel.js
+++ b/app/model/sdl/NonMediaModel.js
@@ -37,16 +37,6 @@ SDL.SDLNonMediaModel = SDL.ABSAppModel.extend({
 
     this._super();
 
-    var subscribeVIData = {};
-
-    for (var key in SDL.SDLVehicleInfoModel.vehicleData) {
-      if (key != 'externalTemperature') {
-        subscribeVIData[key] = false;
-      }
-    }
-
-    this.set('subscribedData', subscribeVIData);
-
     // init properties here
     this.set('appInfo', Em.Object.create({
           field1: '<field1>',

--- a/app/model/sdl/VehicleInfoModel.js
+++ b/app/model/sdl/VehicleInfoModel.js
@@ -340,6 +340,20 @@ SDL.SDLVehicleInfoModel = Em.Object.create(
       FFW.VehicleInfo.GetVehicleTypeResponse(this.vehicleType, id);
     },
     /**
+     * Method to get currently available vehicle data parameters
+     */
+    getAvailableVehicleData: function() {
+      var availableVIData = [];
+
+      for (var key in this.vehicleData) {
+        if (key != 'externalTemperature') {
+          availableVIData.push(key);
+        }
+      }
+
+      return availableVIData;
+    },
+    /**
      * SDL VehicleInfo.GetDTCs handler fill data for response about vehicle
      * errors
      *
@@ -402,25 +416,21 @@ SDL.SDLVehicleInfoModel = Em.Object.create(
      */
     SubscribeVehicleData: function(message) {
       var subscribeVIData = {};
+      var availableData = this.getAvailableVehicleData();
+
       for (var key in message.params) {
         if (key === 'clusterModeStatus') {
           key = 'clusterModes';
         }
-        if (SDL.SDLModel.subscribedData[key] === true) {
-          subscribeVIData[key] = {
-            dataType: this.eVehicleDataType[key],
-            resultCode: 'DATA_ALREADY_SUBSCRIBED'
-          };
-        } else if (key === 'externalTemperature') {
-          subscribeVIData[key] = {
-            dataType: this.eVehicleDataType[key],
-            resultCode: 'VEHICLE_DATA_NOT_AVAILABLE'
-          };
-        } else {
-          SDL.SDLModel.subscribedData[key] = true;
+        if (availableData.indexOf(key) >= 0) {
           subscribeVIData[key] = {
             dataType: this.eVehicleDataType[key],
             resultCode: 'SUCCESS'
+          };
+        } else {
+          subscribeVIData[key] = {
+            dataType: this.eVehicleDataType[key],
+            resultCode: 'VEHICLE_DATA_NOT_AVAILABLE'
           };
         }
       }
@@ -435,32 +445,28 @@ SDL.SDLVehicleInfoModel = Em.Object.create(
      * @type {Object} message
      */
     UnsubscribeVehicleData: function(message) {
-      var subscribeVIData = {};
+      var unsubscribeVIData = {};
+      var availableData = this.getAvailableVehicleData();
+
       for (var key in message.params) {
         if (key === 'clusterModeStatus') {
           key = 'clusterModes';
         }
-        if (SDL.SDLModel.subscribedData[key] === false) {
-          subscribeVIData[key] = {
-            dataType: this.eVehicleDataType[key],
-            resultCode: 'DATA_NOT_SUBSCRIBED'
-          };
-        } else if (key === 'externalTemperature') {
-          subscribeVIData[key] = {
-            dataType: this.eVehicleDataType[key],
-            resultCode: 'VEHICLE_DATA_NOT_AVAILABLE'
-          };
-        } else {
-          SDL.SDLModel.subscribedData[key] = false;
-          subscribeVIData[key] = {
+        if (availableData.indexOf(key) >= 0) {
+          unsubscribeVIData[key] = {
             dataType: this.eVehicleDataType[key],
             resultCode: 'SUCCESS'
+          };
+        } else {
+          unsubscribeVIData[key] = {
+            dataType: this.eVehicleDataType[key],
+            resultCode: 'VEHICLE_DATA_NOT_AVAILABLE'
           };
         }
       }
       FFW.VehicleInfo.sendVISubscribeVehicleDataResult(
         SDL.SDLModel.data.resultCode.SUCCESS, message.id, message.method,
-        subscribeVIData
+        unsubscribeVIData
       );
     },
     /**
@@ -498,22 +504,6 @@ SDL.SDLVehicleInfoModel = Em.Object.create(
       }
     },
     /**
-     * Function send prndl vehicle conditions on FFW.VehicleInfo.OnVehicleData
-     * for notification when data changes
-     */
-    onVehicleDataChanged: function() {
-      var appID = null;
-      for (var i = 0; i < SDL.SDLModel.data.registeredApps.length; i++) {
-        appID = SDL.SDLModel.data.registeredApps[i].appID;
-        if (SDL.SDLModel.subscribedData['prndl']) {
-          var jsonData = {};
-          jsonData['prndl'] = this.vehicleData['prndl'];
-          FFW.VehicleInfo.OnVehicleData(jsonData);
-          return;
-        }
-      }
-    }.observes('this.vehicleData.prndl'),
-    /**
      * Function send gps vehicle conditions on FFW.VehicleInfo.OnVehicleData
      * for notification when data changes
      * @param {Number} lat
@@ -526,12 +516,10 @@ SDL.SDLVehicleInfoModel = Em.Object.create(
       this.set('vehicleData.gps.latitudeDegrees', lat);
       this.set('vehicleData.gps.longitudeDegrees', lng);
       for (var i = 0; i < SDL.SDLModel.data.registeredApps.length; i++) {
-        if (SDL.SDLModel.subscribedData['gps']) {
-          var jsonData = {};
-          jsonData['gps'] = this.vehicleData['gps'];
-          FFW.VehicleInfo.OnVehicleData(jsonData);
-          return;
-        }
+        var jsonData = {};
+        jsonData['gps'] = this.vehicleData['gps'];
+        FFW.VehicleInfo.OnVehicleData(jsonData);
+        return;
       }
     },
     /**


### PR DESCRIPTION
There was a problem that HMI keeps subscription status of applications on `SubscribeVehicleData/UnsubscribeVehicleData` requests is comming. However this is an SDL responsibility
to manage with subscriptions.

In this commit was updated HMI logic to provide only list of available vehicle data and just check requested data using it. All logic related to subscriptions were removed.

### NOTE
This is a PR #33 which just resent to another branch