### PR TITLE
Fix the logic of wayPoints

### DIFF
--- a/app/model/NavigationModel.js
+++ b/app/model/NavigationModel.js
@@ -93,12 +93,6 @@ SDL.NavigationModel = Em.Object.create({
   /**
    * Waypoint markers array
    */
-  WayPointMarkers: [],
-
-  /**
-   *
-   */
-  waypoints: []
-
+  WayPointMarkers: []
 }
 );

--- a/app/model/NavigationModel.js
+++ b/app/model/NavigationModel.js
@@ -93,7 +93,12 @@ SDL.NavigationModel = Em.Object.create({
   /**
    * Waypoint markers array
    */
-  WayPointMarkers: []
+  WayPointMarkers: [],
+
+  /**
+   *
+   */
+  waypoints: []
 
 }
 );

--- a/app/view/navigationView.js
+++ b/app/view/navigationView.js
@@ -148,7 +148,13 @@ SDL.NavigationView = Em.ContainerView.create(
     ),
     WPButton: SDL.Button.extend(
       {
+        isButtonDisabled: function() {
+          return SDL.NavigationModel.WayPointDetails.length == 0 ||
+                 SDL.NavigationController.isAnimateStarted;
+        }.property('SDL.NavigationModel.WayPointDetails',
+                   'SDL.NavigationController.isAnimateStarted'),
         classNameBindings: 'SDL.FuncSwitcher.rev::is-disabled',
+        disabledBinding: 'isButtonDisabled',
         elementId: 'WPButton',
         classNames: 'WPButton button',
         text: 'Waypoints',
@@ -159,6 +165,7 @@ SDL.NavigationView = Em.ContainerView.create(
     AddWP: SDL.Button.extend(
       {
         classNameBindings: 'SDL.FuncSwitcher.rev::is-disabled',
+        disabledBinding: 'SDL.NavigationController.isRouteSet',
         elementId: 'AddWP',
         classNames: 'AddWP button',
         text: 'Add waypoint',
@@ -205,7 +212,6 @@ SDL.NavigationView = Em.ContainerView.create(
         action: 'startAnimation',
         target: 'SDL.NavigationController'
       }
-    ),
-
+    )
   }
 );

--- a/app/view/navigationView.js
+++ b/app/view/navigationView.js
@@ -44,6 +44,7 @@ SDL.NavigationView = Em.ContainerView.create(
       'codeEditor',
       'POIButton',
       'WPButton',
+      'AddWP',
       'map',
       'navigate',
       'animate'
@@ -152,6 +153,16 @@ SDL.NavigationView = Em.ContainerView.create(
         classNames: 'WPButton button',
         text: 'Waypoints',
         action: 'showWpList',
+        target: 'SDL.NavigationController'
+      }
+    ),
+    AddWP: SDL.Button.extend(
+      {
+        classNameBindings: 'SDL.FuncSwitcher.rev::is-disabled',
+        elementId: 'AddWP',
+        classNames: 'AddWP button',
+        text: 'Add waypoint',
+        action: 'addWP',
         target: 'SDL.NavigationController'
       }
     ),

--- a/css/navigation.css
+++ b/css/navigation.css
@@ -64,6 +64,14 @@
     text-align: center;
 }
 
+.AddWP {
+    z-index: 1;
+    top: 335px;
+    left: 245px;
+    width: 125px;
+    text-align: center;
+}
+
 .navigationButton {
     z-index: 1;
     bottom: 60px;


### PR DESCRIPTION
Customer feedback:

> The current sdl hmi sends turn by turn information as wayPoints, that’s not correct.
> For example, if I stop by a grocery store when I drive from work to home, the location of the store is a waypoint. But the turn by turn instructions are not. SDL hmi shall provide method to add and remove waypoints.

Now HMI provides methods for adding and removing wayPoints.