### PR TITLE
Fix start audio/video streaming popup prompt

### DIFF
--- a/ffw/NavigationRPC.js
+++ b/ffw/NavigationRPC.js
@@ -47,6 +47,16 @@ FFW.Navigation = FFW.RPCObserver.create(
      */
     errorResponsePull: {},
     /**
+     * Contains pointer to currently active popup window with start Audio
+     * streaming in the model or null if does not exists
+     */
+    startAudioStreamingPopup: null,
+    /**
+     * Contains pointer to currently active popup window with start Video
+     * streaming in the model or null if does not exists
+     */
+    startVideoStreamingPopup: null,
+    /**
      * access to basic RPC functionality
      */
     client: FFW.RPCClient.create(
@@ -280,7 +290,11 @@ FFW.Navigation = FFW.RPCObserver.create(
           case 'Navigation.StartAudioStream':
           {
             var text = 'Would you like to start Audio stream?';
-            SDL.PopUp.create().appendTo('body').popupActivate(
+            if (this.startAudioStreamingPopup && this.startAudioStreamingPopup.active) {
+              this.startAudioStreamingPopup.deactivate();
+            }
+
+            this.startAudioStreamingPopup = SDL.PopUp.create().appendTo('body').popupActivate(
               text, function(result) {
                 if (result) {
                   FFW.Navigation.sendNavigationResult(
@@ -308,6 +322,10 @@ FFW.Navigation = FFW.RPCObserver.create(
             SDL.SDLController.getApplicationModel(
               request.params.appID
             ).navigationAudioStream = null;
+            if (this.startAudioStreamingPopup && this.startAudioStreamingPopup.active) {
+              this.startAudioStreamingPopup.deactivate();
+              this.set('startAudioStreamingPopup', null);
+            }
             this.sendNavigationResult(
               SDL.SDLModel.data.resultCode.SUCCESS,
               request.id,
@@ -355,7 +373,11 @@ FFW.Navigation = FFW.RPCObserver.create(
           case 'Navigation.StartStream':
           {
             var text = 'Would you like to start Video stream?';
-            SDL.PopUp.create().appendTo('body').popupActivate(
+            if (this.startVideoStreamingPopup && this.startVideoStreamingPopup.active) {
+              this.startVideoStreamingPopup.deactivate();
+            }
+
+            this.startVideoStreamingPopup = SDL.PopUp.create().appendTo('body').popupActivate(
               text, function(result) {
                 if (result) {
                   SDL.SDLController.getApplicationModel(request.params.appID)
@@ -378,6 +400,7 @@ FFW.Navigation = FFW.RPCObserver.create(
             SDL.SDLController.getApplicationModel(
               request.params.appID
             ).navigationStream = request.params.url;
+
             break;
           }
           case 'Navigation.StopStream':
@@ -385,6 +408,10 @@ FFW.Navigation = FFW.RPCObserver.create(
             SDL.SDLController.getApplicationModel(
               request.params.appID
             ).navigationStream = null;
+            if (this.startVideoStreamingPopup && this.startVideoStreamingPopup.active) {
+              this.startVideoStreamingPopup.deactivate();
+              this.set('startVideoStreamingPopup', null);
+            }
             this.sendNavigationResult(
               SDL.SDLModel.data.resultCode.SUCCESS,
               request.id,


### PR DESCRIPTION
The problem is that HMI creates new popup prompt every time when receives `StartStreaming` / `StartAudioStreaming` request from SDL and does not disappear until will be closed manually.
This fix solves a problem by closing previous popup window if new `StartStreaming` request has come and closing active popup window if `StopStreaming` request has come.
In this case HMI will display only one popup window at time during retry sequence and will close popup window if sequence is finished or user clicks OK.

This fix is related to https://github.com/smartdevicelink/sdl_core/issues/1004