### PR TITLE
Fix PTU retry flow with `PROPRIETARY` SystemRequests

### DIFF
--- a/app/controller/SettingsController.js
+++ b/app/controller/SettingsController.js
@@ -341,21 +341,12 @@ SDL.SettingsController = Em.Object.create(
           1000;
         SDL.SDLModel.data.policyUpdateRetry.timer = setTimeout(
           function() {
-            if(FLAGS.ExternalPolicies === true) {
-              FFW.ExternalPolicies.pack({
-                type: 'PROPRIETARY',
-                policyUpdateFile: SDL.SettingsController.policyUpdateFile,
-                url: SDL.SDLModel.data.policyURLs[0].url,
-                appID: SDL.SDLModel.data.policyURLs[0].appID
-              })
-            } else {
-              FFW.BasicCommunication.OnSystemRequest(
-                'PROPRIETARY',
-                SDL.SettingsController.policyUpdateFile,
-                SDL.SDLModel.data.policyURLs[0].url,
-                SDL.SDLModel.data.policyURLs[0].appID
-              );
-            }
+            FFW.BasicCommunication.OnSystemRequest(
+              'PROPRIETARY',
+              SDL.SettingsController.policyUpdateFile,
+              SDL.SDLModel.data.policyURLs[0].url,
+              SDL.SDLModel.data.policyURLs[0].appID
+            );
             SDL.SettingsController.policyUpdateRetry();
           }, SDL.SDLModel.data.policyUpdateRetry.oldTimer
         );

--- a/ffw/BasicCommunicationRPC.js
+++ b/ffw/BasicCommunicationRPC.js
@@ -243,7 +243,10 @@ FFW.BasicCommunication = FFW.RPCObserver
           } else {
             this.OnSystemRequest('PROPRIETARY');
           }
-          SDL.SettingsController.policyUpdateRetry();
+
+          if (FLAGS.ExternalPolicies === true) {
+            SDL.SettingsController.policyUpdateRetry();
+          }
         }
       },
       /**
@@ -289,6 +292,11 @@ FFW.BasicCommunication = FFW.RPCObserver
             case 'UP_TO_DATE':
             {
               messageCode = 'StatusUpToDate';
+              //Update is complete, stop retry sequence
+              if (FLAGS.ExternalPolicies === true) {
+                SDL.SettingsController.policyUpdateRetry('ABORT');
+              }
+              SDL.SettingsController.policyUpdateFile = null;
               break;
             }
             case 'UPDATING':
@@ -397,13 +405,11 @@ FFW.BasicCommunication = FFW.RPCObserver
             SDL.InfoAppsView.showAppList();
           }
           if (request.method == 'BasicCommunication.SystemRequest') {
-            SDL.SettingsController.policyUpdateRetry('ABORT');
             if(FLAGS.ExternalPolicies === true) {
               FFW.ExternalPolicies.unpack(request.params.fileName);
             } else {
               this.OnReceivedPolicyUpdate(request.params.fileName);
             }
-            SDL.SettingsController.policyUpdateFile = null;
             this.sendBCResult(
               SDL.SDLModel.data.resultCode.SUCCESS,
               request.id,


### PR DESCRIPTION
Timeout sequence is managed by Core for PROPRIETARY mode, and HTTP header is only added to snapshot (using the `pack` function) on the first attempt.