### PR TITLE
Fix HMI errors during application registration

### DIFF
--- a/app/view/home/widgetPhoneView.js
+++ b/app/view/home/widgetPhoneView.js
@@ -52,38 +52,39 @@ SDL.WidgetPhoneView = Em.ContainerView.extend({
   }),
 
   rcStatusLabel: SDL.Label.extend(
-			
           {
           	getLabelText: function(){
 
           		if (SDL.SDLModel.appRCStatus.length == 0){
-          			return [];	
-          		} 
+          			return [];
+              }
           		else {
           			var rcStatus = [];
-                    for (var key in SDL.SDLModel.appRCStatus){
+                for (var key in SDL.SDLModel.appRCStatus) {
           				var model = SDL.SDLController.getApplicationModel(+key);
-          				var strHeader = model.appName+': ';
-          				rcStatus.push(strHeader);
-          				if (SDL.SDLModel.appRCStatus[+key].allocated.length > 0){
-          					var allocated = SDL.SDLModel.appRCStatus[+key].allocated;
-          					var allocatedStr = 'Allocates:';
-          					for (var i = 0; i < allocated.length; ++i) {
-          						allocatedStr += (i>0)? ', ': ' ';
-          						allocatedStr += allocated[i].moduleType.toLowerCase() ;  							 					
-          					}
-          					rcStatus.push(allocatedStr);
-          				}
+                  if (model && model.appName) {
+            				var strHeader = model.appName+': ';
+            				rcStatus.push(strHeader);
+            				if (SDL.SDLModel.appRCStatus[+key].allocated.length > 0){
+            					var allocated = SDL.SDLModel.appRCStatus[+key].allocated;
+            					var allocatedStr = 'Allocates:';
+            					for (var i = 0; i < allocated.length; ++i) {
+            						allocatedStr += (i>0)? ', ': ' ';
+            						allocatedStr += allocated[i].moduleType.toLowerCase() ;
+            					}
+            					rcStatus.push(allocatedStr);
+            				}
 
-          				if (SDL.SDLModel.appRCStatus[+key].free.length > 0){
-          					var free = SDL.SDLModel.appRCStatus[+key].free;
-          					var freeStr = 'Can allocate:';
-          					for (var i = 0; i < free.length; ++i) {
-          						freeStr += (i>0)? ', ': ' ';
-          						freeStr += free[i].moduleType.toLowerCase() ;  							        						
-          					}
-          					rcStatus.push(freeStr);
-          				}
+            				if (SDL.SDLModel.appRCStatus[+key].free.length > 0){
+            					var free = SDL.SDLModel.appRCStatus[+key].free;
+            					var freeStr = 'Can allocate:';
+            					for (var i = 0; i < free.length; ++i) {
+            						freeStr += (i>0)? ', ': ' ';
+            						freeStr += free[i].moduleType.toLowerCase() ;
+            					}
+            					rcStatus.push(freeStr);
+            				}
+                  }
           			}
           			return rcStatus;
           		}

--- a/app/view/info/appsView.js
+++ b/app/view/info/appsView.js
@@ -66,52 +66,21 @@ SDL.InfoAppsView = Em.ContainerView.create({
     var i, apps = SDL.SDLModel.data.registeredApps, appIndex;
 
     for (i = 0; i < apps.length; i++) {
-      if (apps[i].appType.indexOf('REMOTE_CONTROL') === -1) {
-        appIndex = SDL.SDLModel.data.registeredApps.indexOf(apps[i]);
+      appIndex = SDL.SDLModel.data.registeredApps.indexOf(apps[i]);
 
-        this.get('listOfApplications.list.childViews').
-               pushObject(SDL.Button.create({
-                   action: 'onActivateSDLApp',
-                   target: 'SDL.SDLController',
-                   text: apps[i].appName + ' - ' + apps[i].deviceName,
-                   appName: apps[i].appName,
-                   appID: apps[i].appID,
-                   classNames: 'list-item button',
-                   iconBinding: 'SDL.SDLModel.data.registeredApps.' + appIndex +
-                   '.appIcon',
-                   disabled: apps[i].disabledToActivate
-                 }
-                 )
-               );
-      } else if (apps[i].appType.indexOf('REMOTE_CONTROL') != -1 &&
-        apps[i].level != 'NONE' &&
-        apps[i].level != 'BACKGROUND' ||
-        SDL.SDLModel.driverDeviceInfo &&
-        apps[i].deviceName === SDL.SDLModel.driverDeviceInfo.name) {
-
-        var driverDevice = (
-        SDL.SDLModel.driverDeviceInfo &&
-        apps[i].deviceName == SDL.SDLModel.driverDeviceInfo.name);
-
-        appIndex = SDL.SDLModel.data.registeredApps.indexOf(apps[i]);
-
-        this.get('listOfApplications.list.childViews').
-               pushObject(SDL.Button.create({
-                   action: driverDevice ? 'onActivateSDLApp' :
-                     'onDeactivatePassengerApp',
-                   target: 'SDL.SDLController',
-                   text: apps[i].appName + ' - ' + apps[i].deviceName,
-                   appName: apps[i].appName,
-                   appID: apps[i].appID,
-                   classNames: 'list-item button',
-                   iconBinding: 'SDL.SDLModel.data.registeredApps.' + appIndex +
-                   '.appIcon',
-                   disabled: false
-                 })
-               );
-      }
+      this.get('listOfApplications.list.childViews').
+        pushObject(SDL.Button.create({
+          action: 'onActivateSDLApp',
+          target: 'SDL.SDLController',
+          text: apps[i].appName + ' - ' + apps[i].deviceName,
+          appName: apps[i].appName,
+          appID: apps[i].appID,
+          classNames: 'list-item button',
+          iconBinding: 'SDL.SDLModel.data.registeredApps.' + appIndex + '.appIcon',
+          disabled: apps[i].disabledToActivate
+        })
+      );
     }
-
   },
 
   vehicleHealthReport: SDL.Button.extend({


### PR DESCRIPTION
The following changes were done:
- Fix errors while handling OnRCStatus notification. 
Sometimes application model for specified app_id could not be found in RPCController array and it returns null object. However widgetPhone view does not handle that case so sometimes it could be seen errors in console output related to that problem.
- Removed redundant logic for checking RC applications
There was a problem that RC applications from another device was not displayed in HMI app list. This issue was related to redundant logic of checking RC application properties such as device info. Now this logic is not required so RC applications must behave as well as non-RC applications.
