### PR TITLE
Fixed 'split on undefined' error in TTSPopUp

### DIFF
--- a/app/view/sdl/TTSPopUp.js
+++ b/app/view/sdl/TTSPopUp.js
@@ -110,7 +110,7 @@ SDL.TTSPopUp = Em.ContainerView.create(
       this.set('appID', appID);
       this.set('content', msg);
 
-      if (files != '') {
+      if (files != undefined && files != '') {
         var files_to_play = files.split('\n');
         for (var i = 0; i < files_to_play.length; ++i) {
           this.player.addFile(files_to_play[i]);


### PR DESCRIPTION
The split function was causing an error when the files were undefined. Adding the fix makes the HMI automatically redirect to the app permissions page in the settings when using external policies.