### PR TITLE
Add missed seatControlCapabilities to Hmi Cpabilities

### DIFF
--- a/capabilities/rc_capabilities.js
+++ b/capabilities/rc_capabilities.js
@@ -133,6 +133,24 @@ SDL.remoteControlCapability =
         keepContextAvailable: true,
         equalizerMaxChannelId: 10
     }],
+    seatControlCapabilities: [{
+      moduleName: "Seat",
+      heatingEnabledAvailable: true,
+      coolingEnabledAvailable: true,
+      heatingLevelAvailable: true,
+      coolingLevelAvailable: true,
+      horizontalPositionAvailable: true,
+      verticalPositionAvailable: true,
+      frontVerticalPositionAvailable: true,
+      backVerticalPositionAvailable: true,
+      backTiltAngleAvailable: true,
+      headSupportHorizontalPositionAvailable: true,
+      headSupportVerticalPositionAvailable: true,
+      massageEnabledAvailable: true,
+      massageModeAvailable: true,
+      massageCushionFirmnessAvailable: true,
+      memoryAvailable: true
+   }],
     lightControlCapabilities: {
         moduleName: 'light',
         supportedLights: [{


### PR DESCRIPTION
Fixes #143 

This PR is **[ready]** for review.


### Summary
Added default seatControlCapabilities to  hmi capabilities file. 
This is needed for sending correct information from HMI to SDL during initialization.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)