### PR TITLE
 App permissions list was fixed

### DIFF
--- a/app/controller/SettingsController.js
+++ b/app/controller/SettingsController.js
@@ -240,6 +240,9 @@ SDL.SettingsController = Em.Object.create(
       );
     },
     simpleParseUserFriendlyMessageData: function(messages, func) {
+      if(!messages) {
+        return;
+      }
       var tts = '',
         text = '';
       messages.forEach(

--- a/app/view/settings/policies/appPermissionsView.js
+++ b/app/view/settings/policies/appPermissionsView.js
@@ -90,6 +90,9 @@ SDL.AppPermissionsView = Em.ContainerView.create(
       SDL.AppPermissionsView.currentAppId = appID;
       this.appList.items = [];
       for (var i = 0; i < message.length; i++) {
+        if(!message[i].name){
+          continue;
+        }
         var text = ' - Undefined';
         text = (message[i].allowed === true) ? ' - Allowed' : ' - Not allowed';
         this.appList.items.push({


### PR DESCRIPTION
Fixes [#148](https://github.com/smartdevicelink/sdl_hmi/issues/148)

This PR is **[ready]** for review.   

### Summary
There was a problem that HMI displays wrong permission group names in the list of app permissions to consent.
In this PR was added check to avoid displaying of functional groups not related to the selected application. That solves a problem and HMI displays only groups which actually requires user consent since last PTU.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)