### PR TITLE
Remove HMI implementation of unused RPC which was removed from core

### DIFF
--- a/app/BasicCommunicationRPC.js
+++ b/app/BasicCommunicationRPC.js
@@ -376,9 +376,6 @@ FFW.BasicCommunication = FFW.RPCObserver
           if (request.method == 'BasicCommunication.AllowApp') {
             this.AllowApp(request);
           }
-          if (request.method == 'BasicCommunication.AllowDeviceToConnect') {
-            this.AllowDeviceToConnect(request.id, request.method, true);
-          }
           if (request.method == 'BasicCommunication.UpdateDeviceList') {
             SDL.SDLModel.onGetDeviceList(request.params);
             this.sendBCResult(
@@ -701,32 +698,6 @@ FFW.BasicCommunication = FFW.RPCObserver
           };
           this.client.send(JSONMessage);
         }
-      },
-      /**
-       * send response from onRPCRequest
-       *
-       * @param {Number}
-       *            id
-       * @param {String}
-       *            method
-       * @param {Boolean}
-       *            allow
-       */
-      AllowDeviceToConnect: function(id, method, allow) {
-        Em.Logger.log('FFW.' + method + 'Response');
-        // send repsonse
-        var JSONMessage = {
-          'jsonrpc': '2.0',
-          'id': id,
-          'result': {
-            'code': SDL.SDLModel.data.resultCode.SUCCESS, // type (enum)
-            // from SDL
-            // protocol
-            'method': method,
-            'allow': allow
-          }
-        };
-        this.client.send(JSONMessage);
       },
       /**
        * Response with params of the last one supports mixing audio (ie

--- a/app/controller/sdl/RPCController.js
+++ b/app/controller/sdl/RPCController.js
@@ -382,32 +382,6 @@ SDL.RPCController = Em.Object.create(
           return this.resultStruct;
         },
         /**
-         * Validate method for request AllowDeviceToConnect
-         *
-         * @param {Object}
-         *            params
-         */
-        AllowDeviceToConnect: function(params) {
-          if (params == null) {
-            this.resultStruct = {
-              'resultCode': SDL.SDLModel.data.resultCode.INVALID_DATA,
-              'resultMessage': 'Parameter \'params\' does not exists!'
-            };
-            return this.resultStruct;
-          }
-          if (params.device == null) {
-            this.resultStruct = {
-              'resultCode': SDL.SDLModel.data.resultCode.INVALID_DATA,
-              'resultMessage': 'Parameter \'device\' does not exists!'
-            };
-            return this.resultStruct;
-          }
-          this.resultStruct = {
-            'resultCode': SDL.SDLModel.data.resultCode.SUCCESS
-          };
-          return this.resultStruct;
-        },
-        /**
          * Validate method for request GetSystemInfo
          *
          * @param {Object}

--- a/ffw/BasicCommunicationRPC.js
+++ b/ffw/BasicCommunicationRPC.js
@@ -387,9 +387,6 @@ FFW.BasicCommunication = FFW.RPCObserver
           if (request.method == 'BasicCommunication.AllowApp') {
             this.AllowApp(request);
           }
-          if (request.method == 'BasicCommunication.AllowDeviceToConnect') {
-            this.AllowDeviceToConnect(request.id, request.method, true);
-          }
           if (request.method == 'BasicCommunication.UpdateDeviceList') {
             SDL.SDLModel.onGetDeviceList(request.params);
             this.sendBCResult(
@@ -740,32 +737,6 @@ FFW.BasicCommunication = FFW.RPCObserver
           };
           this.client.send(JSONMessage);
         }
-      },
-      /**
-       * send response from onRPCRequest
-       *
-       * @param {Number}
-       *            id
-       * @param {String}
-       *            method
-       * @param {Boolean}
-       *            allow
-       */
-      AllowDeviceToConnect: function(id, method, allow) {
-        Em.Logger.log('FFW.' + method + 'Response');
-        // send repsonse
-        var JSONMessage = {
-          'jsonrpc': '2.0',
-          'id': id,
-          'result': {
-            'code': SDL.SDLModel.data.resultCode.SUCCESS, // type (enum)
-            // from SDL
-            // protocol
-            'method': method,
-            'allow': allow
-          }
-        };
-        this.client.send(JSONMessage);
       },
       /**
        * Response with params of the last one supports mixing audio (ie


### PR DESCRIPTION
PR to remove `AllowDeviceToConnect` (unused RPC)  implementation in HMI. The RPC has already been removed from core (https://github.com/smartdevicelink/sdl_core/pull/2057)