### PR TITLE
Fix issue with policy table update

### DIFF
--- a/app/Flags.js
+++ b/app/Flags.js
@@ -61,6 +61,10 @@ FLAGS = Em.Object.create(
      * 2 - P
      */
     SimpleFunctionality: 1,
-    ExternalPolicies: false
+    ExternalPolicies: false,
+    ProprietaryPolicies: true,
+    HTTPPolicies: false
+
+    
   }
 );

--- a/app/model/sdl/Abstract/data.js
+++ b/app/model/sdl/Abstract/data.js
@@ -652,6 +652,11 @@ SDL.SDLModelData = Em.Object.create(
       'Day mode',
       'Night mode',
       'Highlighted mode'
+    ],
+    policiesList: [
+      'PROPRIETARY',
+      'EXTERNAL_PROPRIETARY',
+      'HTTP'
     ]
   }
 );

--- a/app/view/WarningView.js
+++ b/app/view/WarningView.js
@@ -424,24 +424,28 @@ SDL.warningView = Em.ContainerView
                       'SDL.FuncSwitcher.rev::not-visible'
                     ],
                     childViews: [
-                      'checkBox',
-                      'text'
+                      'select'
                     ],
-                    checkBox: Em.Checkbox.extend(
+                    select: Em.Select.extend(
                       {
-                        elementId: 'externalPoliciesCheckBox',
-                        classNames: 'externalPoliciesCheckBox item',
-                        checkedBinding: 'FLAGS.ExternalPolicies'
-                      }
-                    ),
-                    text: SDL.Label.extend(
-                      {
-                        tagName: 'label',
-                        attributeBindings: [
-                          'this.parentView.checkBox.elementId:for'
-                        ],
-                        classNames: 'externalPoliciesText item',
-                        content: 'External Policies'
+                        contentBinding: 'SDL.SDLModel.data.policiesList',
+                        classNames: 'externalPoliciesCheckBox select',
+                        change: function() {
+                          var value = this.selection;
+                          FLAGS.set('ExternalPolicies', false),
+                          FLAGS.set('ProprietaryPolicies', false),
+                          FLAGS.set('HTTPPolicies', false)
+                          if('EXTERNAL_PROPRIETARY' == value) {
+                            FLAGS.set('ExternalPolicies', true)
+                          }
+                          if('PROPRIETARY' == value) {
+                            FLAGS.set('ProprietaryPolicies', true)
+                          }
+                          if('HTTP' == value) {
+                            FLAGS.set('HTTPPolicies', true)
+                          }
+
+                        }
                       }
                     )
                   }

--- a/app/view/sdl/ExitAppView.js
+++ b/app/view/sdl/ExitAppView.js
@@ -152,7 +152,10 @@ SDL.ExitApp = Em.ContainerView.create(
     classNames: 'button sendSignalButton',
     text: 'Send signal',
     action:function(){
-      FFW.RPCSimpleClient.send(SDL.ExitApp.signalSelect.selection.name);
+      var JSONMessage = {
+        'params': SDL.ExitApp.signalSelect.selection.name
+      };
+      FFW.RPCSimpleClient.send(JSONMessage);
     },
     target: 'SDL.SDLController',
     buttonAction: true,

--- a/css/general.css
+++ b/css/general.css
@@ -1346,6 +1346,15 @@ input[type=radio]:checked ~ .label {
     -webkit-transition: all 0.25s linear;
 }
 
+ .select {
+    position: relative;
+    float: left;
+    margin-left: 10px;
+    color: black;
+    cursor: pointer;
+    -webkit-transition: all 0.25s linear;
+ }
+
 #warning_view .item:hover{
     color: #FFFFFF;
 }

--- a/ffw/BasicCommunicationRPC.js
+++ b/ffw/BasicCommunicationRPC.js
@@ -405,16 +405,16 @@ FFW.BasicCommunication = FFW.RPCObserver
             SDL.InfoAppsView.showAppList();
           }
           if (request.method == 'BasicCommunication.SystemRequest') {
-            if(FLAGS.ExternalPolicies === true) {
-              FFW.ExternalPolicies.unpack(request.params.fileName);
-            } else {
-              this.OnReceivedPolicyUpdate(request.params.fileName);
-            }
-            this.sendBCResult(
-              SDL.SDLModel.data.resultCode.SUCCESS,
-              request.id,
-              request.method
-            );
+            if(FLAGS.HTTPPolicies === false) {
+              var JSONMessage = {
+                'params': {
+                  'method': request.method,
+                  'filename': request.params.fileName,
+                  'id': request.id
+                }
+              };
+              FFW.RPCSimpleClient.send(JSONMessage);
+            } 
           }
           if (request.method == 'BasicCommunication.DialNumber') {
             SDL.PopUp.create().appendTo('body').popupActivate(
@@ -507,6 +507,17 @@ FFW.BasicCommunication = FFW.RPCObserver
             this.client.send(JSONMessage);
           }
           if (request.method == 'BasicCommunication.PolicyUpdate') {
+            if(FLAGS.ExternalPolicies) {
+              var JSONMessage = {
+                'params': {
+                  'method': request.method,
+                  'file': request.params.file,
+                  'id': request.id
+                }
+              };
+              FFW.RPCSimpleClient.send(JSONMessage);
+              return;
+            }
             SDL.SettingsController.policyUpdateFile = request.params.file;
             SDL.SDLModel.data.policyUpdateRetry.timeout
               = request.params.timeout;


### PR DESCRIPTION
Fixes #150 #151

### Summary
There were a problems when HMI doesn't add HTTP header to
SDL policy table snapshot in case of EXTERNAL_PROPRIETARY flow
and when HMI doesn't remove root data element from policy table
update file in case EXTERNAL_PROPRIETARY and PROPRIETARY flow.

