### PR TITLE
HMI desn't remove root 'data' element from policy table update file

### DIFF
--- a/app/Flags.js
+++ b/app/Flags.js
@@ -61,6 +61,10 @@ FLAGS = Em.Object.create(
      * 2 - P
      */
     SimpleFunctionality: 1,
-    ExternalPolicies: false
+    ExternalPolicies: false,
+    ProprietaryPolicies: true,
+    HTTPPolicies: false
+
+    
   }
 );

--- a/app/model/sdl/Abstract/data.js
+++ b/app/model/sdl/Abstract/data.js
@@ -652,6 +652,11 @@ SDL.SDLModelData = Em.Object.create(
       'Day mode',
       'Night mode',
       'Highlighted mode'
+    ],
+    policiesList: [
+      'PROPRIETARY',
+      'EXTERNAL_PROPRIETARY',
+      'HTTP'
     ]
   }
 );

--- a/app/view/WarningView.js
+++ b/app/view/WarningView.js
@@ -424,24 +424,28 @@ SDL.warningView = Em.ContainerView
                       'SDL.FuncSwitcher.rev::not-visible'
                     ],
                     childViews: [
-                      'checkBox',
-                      'text'
+                      'select'
                     ],
-                    checkBox: Em.Checkbox.extend(
+                    select: Em.Select.extend(
                       {
-                        elementId: 'externalPoliciesCheckBox',
-                        classNames: 'externalPoliciesCheckBox item',
-                        checkedBinding: 'FLAGS.ExternalPolicies'
-                      }
-                    ),
-                    text: SDL.Label.extend(
-                      {
-                        tagName: 'label',
-                        attributeBindings: [
-                          'this.parentView.checkBox.elementId:for'
-                        ],
-                        classNames: 'externalPoliciesText item',
-                        content: 'External Policies'
+                        contentBinding: 'SDL.SDLModel.data.policiesList',
+                        classNames: 'externalPoliciesCheckBox select',
+                        change: function() {
+                          var value = this.selection;
+                          FLAGS.set('ExternalPolicies', false),
+                          FLAGS.set('ProprietaryPolicies', false),
+                          FLAGS.set('HTTPPolicies', false)
+                          if('EXTERNAL_PROPRIETARY' == value) {
+                            FLAGS.set('ExternalPolicies', true)
+                          }
+                          if('PROPRIETARY' == value) {
+                            FLAGS.set('ProprietaryPolicies', true)
+                          }
+                          if('HTTP' == value) {
+                            FLAGS.set('HTTPPolicies', true)
+                          }
+
+                        }
                       }
                     )
                   }

--- a/app/view/sdl/ExitAppView.js
+++ b/app/view/sdl/ExitAppView.js
@@ -152,7 +152,10 @@ SDL.ExitApp = Em.ContainerView.create(
     classNames: 'button sendSignalButton',
     text: 'Send signal',
     action:function(){
-      FFW.RPCSimpleClient.send(SDL.ExitApp.signalSelect.selection.name);
+      var JSONMessage = {
+        'params': SDL.ExitApp.signalSelect.selection.name
+      };
+      FFW.RPCSimpleClient.send(JSONMessage);
     },
     target: 'SDL.SDLController',
     buttonAction: true,

--- a/css/general.css
+++ b/css/general.css
@@ -1346,6 +1346,15 @@ input[type=radio]:checked ~ .label {
     -webkit-transition: all 0.25s linear;
 }
 
+ .select {
+    position: relative;
+    float: left;
+    margin-left: 10px;
+    color: black;
+    cursor: pointer;
+    -webkit-transition: all 0.25s linear;
+ }
+
 #warning_view .item:hover{
     color: #FFFFFF;
 }

--- a/ffw/BasicCommunicationRPC.js
+++ b/ffw/BasicCommunicationRPC.js
@@ -415,6 +415,11 @@ FFW.BasicCommunication = FFW.RPCObserver
               };
               FFW.RPCSimpleClient.send(JSONMessage);
             }
+            this.sendBCResult(
+              SDL.SDLModel.data.resultCode.SUCCESS,
+              request.id,
+              request.method
+            );
           }
           if (request.method == 'BasicCommunication.DialNumber') {
             SDL.PopUp.create().appendTo('body').popupActivate(

--- a/ffw/BasicCommunicationRPC.js
+++ b/ffw/BasicCommunicationRPC.js
@@ -405,16 +405,16 @@ FFW.BasicCommunication = FFW.RPCObserver
             SDL.InfoAppsView.showAppList();
           }
           if (request.method == 'BasicCommunication.SystemRequest') {
-            if(FLAGS.ExternalPolicies === true) {
-              FFW.ExternalPolicies.unpack(request.params.fileName);
-            } else {
-              this.OnReceivedPolicyUpdate(request.params.fileName);
+            if(FLAGS.HTTPPolicies === false) {
+              var JSONMessage = {
+                'params': {
+                  'method': request.method,
+                  'filename': request.params.fileName,
+                  'id': request.id
+                }
+              };
+              FFW.RPCSimpleClient.send(JSONMessage);
             }
-            this.sendBCResult(
-              SDL.SDLModel.data.resultCode.SUCCESS,
-              request.id,
-              request.method
-            );
           }
           if (request.method == 'BasicCommunication.DialNumber') {
             SDL.PopUp.create().appendTo('body').popupActivate(

--- a/ffw/RPCSimpleClient.js
+++ b/ffw/RPCSimpleClient.js
@@ -92,6 +92,9 @@ FFW.RPCSimpleClient = Em.Object.create({
     onWSMessage: function(evt) {
       Em.Logger.log('Message received: ' + evt.data);
       var jsonObj = JSON.parse(evt.data);
+      if(jsonObj.params.method == 'SDL.OnReceivedPolicyUpdate') {
+        FFW.BasicCommunication.OnReceivedPolicyUpdate(jsonObj.params.filename);
+      }
       FFW.BasicCommunication.sendBCResult(
         SDL.SDLModel.data.resultCode.SUCCESS, jsonObj.params.id, jsonObj.params.method
       );

--- a/tools/start_server.py
+++ b/tools/start_server.py
@@ -49,6 +49,8 @@ def message_received(client, server, message):
 	if 'method' in data["params"]:
 		if data['params']['method'] == 'BasicCommunication.SystemRequest':
 			systemRequestEraseData(data['params']['filename'])
+			data['params']['method'] = 'SDL.OnReceivedPolicyUpdate'
+			message = json.dumps(data)
 			server.send_message(client,message)
 			return
 
@@ -63,7 +65,7 @@ def systemRequestEraseData(path):
 	data = json.loads(content)
 
 	if 'data' in data:
-		data = data['data']
+		data = data['data'][0]
 		data_to_write = json.dumps(data)
 
 		file = open(path,'w')


### PR DESCRIPTION
Fixes #151

### Summary
There was a problem when HMI doesn't remove root data element
from policy table update file in case EXTERNAL_PROPRIETARY
and PROPRIETARY flow.