### PR TITLE
Add cloudAppVehicleID to vi model

### DIFF
--- a/app/model/sdl/VehicleInfoModel.js
+++ b/app/model/sdl/VehicleInfoModel.js
@@ -134,7 +134,8 @@ SDL.SDLVehicleInfoModel = Em.Object.create(
       'abs_State': 'VEHICLEDATA_ABS_STATE',
       'turnSignal': 'VEHICLEDATA_TURNSIGNAL',
       'tirePressureValue': 'VEHICLEDATA_TIREPRESSURE_VALUE',
-      'tpms': 'VEHICLEDATA_TPMS'
+      'tpms': 'VEHICLEDATA_TPMS',
+      'cloudAppVehicleID': 'VEHICLEDATA_CLOUDAPPVEHICLEID'
     },
     /**
      * Stored VehicleInfo Data
@@ -304,7 +305,8 @@ SDL.SDLVehicleInfoModel = Em.Object.create(
         'frontRecommended': 2.2E0,
         'rearRecommended': 2.2E0
       },
-      'tpms': 'TIRES_NOT_TRAINED'
+      'tpms': 'TIRES_NOT_TRAINED',
+      'cloudAppVehicleID': 'SDLVehicleNo123'
       //
       // 'avgFuelEconomy': 0.1,
       // 'batteryVoltage': 12.5,


### PR DESCRIPTION
Add new vehicle data parameter CloudAppVehicleID. This string value is used by cloud apps to identify a vehicle for saved user preferences and settings. 

Relevant [proposal](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0158-cloud-app-transport-adapter.md#cloudappvehicleid)