### PR TITLE
Block Cloud Device From Driver Device Assignment

### DIFF
--- a/app/model/sdl/Abstract/Model.js
+++ b/app/model/sdl/Abstract/Model.js
@@ -868,7 +868,12 @@ SDL.SDLModel = Em.Object.extend({
 
     if (SDL.SDLModel.driverDevice && SDL.SDLModel.driverDeviceInfo === null &&
       params.deviceList.length > 0) {
-      SDL.SDLModel.set('driverDeviceInfo', params.deviceList[0]);
+      for(var i = 0; i<params.deviceList.length; i++) {
+        if(params.deviceList[i].transportType != "CLOUD_WEBSOCKET") {
+          SDL.SDLModel.set('driverDeviceInfo', params.deviceList[i]);
+        }
+      }
+      
 
       // According to SDL.SDLModel.deviceRank enum 0 - is driver's device
       FFW.RC.OnDeviceRankChanged(params.deviceList[0],

--- a/app/model/sdl/Abstract/Model.js
+++ b/app/model/sdl/Abstract/Model.js
@@ -868,9 +868,10 @@ SDL.SDLModel = Em.Object.extend({
 
     if (SDL.SDLModel.driverDevice && SDL.SDLModel.driverDeviceInfo === null &&
       params.deviceList.length > 0) {
-      for(var i = 0; i<params.deviceList.length; i++) {
-        if(params.deviceList[i].transportType != "CLOUD_WEBSOCKET") {
+      for (var i = 0; i<params.deviceList.length; i++) {
+        if (params.deviceList[i].transportType != "CLOUD_WEBSOCKET") {
           SDL.SDLModel.set('driverDeviceInfo', params.deviceList[i]);
+          break;
         }
       }
       

--- a/app/model/sdl/RModel.js
+++ b/app/model/sdl/RModel.js
@@ -148,7 +148,7 @@ SDL.RModel = SDL.SDLModel.extend({
     }
 
     if (this.driverDevice && this.driverDeviceInfo == null) {
-      if (params.deviceInfo) {
+      if (params.deviceInfo && params.deviceInfo.transportType != "CLOUD_WEBSOCKET") {
         this.set('driverDeviceInfo', params.deviceInfo);
       }
     }

--- a/app/model/sdl/VehicleInfoModel.js
+++ b/app/model/sdl/VehicleInfoModel.js
@@ -134,7 +134,8 @@ SDL.SDLVehicleInfoModel = Em.Object.create(
       'abs_State': 'VEHICLEDATA_ABS_STATE',
       'turnSignal': 'VEHICLEDATA_TURNSIGNAL',
       'tirePressureValue': 'VEHICLEDATA_TIREPRESSURE_VALUE',
-      'tpms': 'VEHICLEDATA_TPMS'
+      'tpms': 'VEHICLEDATA_TPMS',
+      'cloudAppVehicleID': 'VEHICLEDATA_CLOUDAPPVEHICLEID'
     },
     /**
      * Stored VehicleInfo Data
@@ -304,7 +305,8 @@ SDL.SDLVehicleInfoModel = Em.Object.create(
         'frontRecommended': 2.2E0,
         'rearRecommended': 2.2E0
       },
-      'tpms': 'TIRES_NOT_TRAINED'
+      'tpms': 'TIRES_NOT_TRAINED',
+      'cloudAppVehicleID': 'SDLVehicleNo123'
       //
       // 'avgFuelEconomy': 0.1,
       // 'batteryVoltage': 12.5,


### PR DESCRIPTION
Check that a device transport type is not equal to "CLOUD_WEBSOCKET" before choosing a "driver device".