### PR TITLE
Add logic for BC.CloseApplication RPC

### DIFF
--- a/app/BasicCommunicationRPC.js
+++ b/app/BasicCommunicationRPC.js
@@ -475,6 +475,14 @@ FFW.BasicCommunication = FFW.RPCObserver
               SDL.SDLModel.data.resultCode.SUCCESS, request.id, request.method
             );
           }
+          if (request.method == 'BasicCommunication.CloseApplication') {
+            SDL.SDLController.getApplicationModel(request.params.appID).level
+              = 'NONE';
+            SDL.SDLController.closeApplication(request.params.appID);
+            this.sendBCResult(
+              SDL.SDLModel.data.resultCode.SUCCESS, request.id, request.method
+            );
+          }
           if (request.method == 'BasicCommunication.GetSystemInfo') {
             Em.Logger.log('BasicCommunication.GetSystemInfo Response');
             // send repsonse

--- a/app/controller/sdl/Abstract/Controller.js
+++ b/app/controller/sdl/Abstract/Controller.js
@@ -164,6 +164,14 @@ SDL.SDLController = Em.Object.extend(
     },
     userExitAction: function(appID) {
       FFW.BasicCommunication.ExitApplication(appID, 'USER_EXIT');
+      this.closeApplication(appID);
+    },
+    /**
+     * Handler for CloseApplication RPC
+     *
+     * @param appID {Number}
+     */
+    closeApplication: function(appID) {
       if (SDL.States.currentState.getPath('path') === 'media.sdlmedia' ||
         SDL.States.currentState.getPath('path') === 'info.nonMedia') {
         SDL.States.goToStates('info.apps');

--- a/app/controller/sdl/RPCController.js
+++ b/app/controller/sdl/RPCController.js
@@ -349,6 +349,39 @@ SDL.RPCController = Em.Object.create(
           return this.resultStruct;
         },
         /**
+         * Validate method for request CloseApplication
+         *
+         * @param {Object}
+         *            params
+         */
+        CloseApplication: function(params) {
+          if (params == null) {
+            this.resultStruct = {
+              'resultCode': SDL.SDLModel.data.resultCode.INVALID_DATA,
+              'resultMessage': 'Parameter \'params\' does not exists!'
+            };
+            return this.resultStruct;
+          }
+          if (params.appID == null) {
+            this.resultStruct = {
+              'resultCode': SDL.SDLModel.data.resultCode.INVALID_DATA,
+              'resultMessage': 'Parameter \'appID\' does not exists!'
+            };
+            return this.resultStruct;
+          }
+          if (typeof params.appID != 'number') {
+            this.resultStruct = {
+              'resultCode': SDL.SDLModel.data.resultCode.INVALID_DATA,
+              'resultMessage': 'Wrong type of parameter \'appID\'!'
+            };
+            return this.resultStruct;
+          }
+          this.resultStruct = {
+            'resultCode': SDL.SDLModel.data.resultCode.SUCCESS
+          };
+          return this.resultStruct;
+        },
+        /**
          * Validate method for request AllowSDLFunctionality
          *
          * @param {Object}

--- a/ffw/BasicCommunicationRPC.js
+++ b/ffw/BasicCommunicationRPC.js
@@ -488,6 +488,14 @@ FFW.BasicCommunication = FFW.RPCObserver
               SDL.SDLModel.data.resultCode.SUCCESS, request.id, request.method
             );
           }
+          if (request.method == 'BasicCommunication.CloseApplication') {
+            SDL.SDLController.getApplicationModel(request.params.appID).level
+              = 'NONE';
+            SDL.SDLController.closeApplication(request.params.appID);
+            this.sendBCResult(
+              SDL.SDLModel.data.resultCode.SUCCESS, request.id, request.method
+            );
+          }
           if (request.method == 'BasicCommunication.GetSystemInfo') {
             Em.Logger.log('BasicCommunication.GetSystemInfo Response');
             // send repsonse


### PR DESCRIPTION
Implements [#1931](https://github.com/smartdevicelink/sdl_core/issues/1931)

This PR is **ready** for review.

### Testing Plan
Send CloseApplication from mobile application while in FULL, verify that the application returns to NONE and leaves the foreground of the HMI.

### Summary
Add logic for `BC.CloseApplication` RPC

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
