### PR TITLE
BasicCommunication.onReady notification send two times instead of one…

### DIFF
--- a/app/controller/sdl/Abstract/Controller.js
+++ b/app/controller/sdl/Abstract/Controller.js
@@ -321,6 +321,7 @@ SDL.SDLController = Em.Object.extend(
       for (var i = 0; i < SDL.SDLModel.data.registeredComponents.length; i++) {
         if (SDL.SDLModel.data.registeredComponents[i].type == component) {
           SDL.SDLModel.data.set('registeredComponents.' + i + '.state', true);
+          this.componentsReadiness();
           return;
         }
       }
@@ -422,7 +423,7 @@ SDL.SDLController = Em.Object.extend(
         }
       }
       FFW.BasicCommunication.onReady();
-    }.observes('SDL.SDLModel.data.registeredComponents.@each.state'),
+    },
     /**
      * Show VrHelpItems popup with necessary params
      * if VRPopUp is active - show data from Global Properties


### PR DESCRIPTION
Implements/Fixes #218 

This PR is **ready** for review.

### Testing Plan
Manual testing

### Summary
The problem was in `Controller.js` `componentsReadiness` callback method
which observed changes in `SDL.SDLModel.data.registeredComponents` and called
twice after changes. It's a problem in the `Ember` framework.
Solution is to call method `componentsReadiness` from the method where this
data changed. It will call one time.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
