### PR TITLE
send choice_id when an interaction succeeds

### DIFF
--- a/ffw/UIRPC.js
+++ b/ffw/UIRPC.js
@@ -1233,26 +1233,26 @@ FFW.UI = FFW.RPCObserver.create(
       if (this.errorResponsePull[requestID] &&
         resultCode === SDL.SDLModel.data.resultCode.SUCCESS) {
 
-        // send repsonse
-        var JSONMessage = {
+        var json = {
           'jsonrpc': '2.0',
           'id': requestID,
-          'error': {
-            'code': this.errorResponsePull[requestID].code,
-            'message': 'Unsupported ' + this.errorResponsePull[requestID].type +
-            ' type. Available data in request was processed.',
-            'data': {
-              'method': 'UI.PerformInteraction'
-            }
+          'result': {
+            'code': SDL.SDLModel.data.resultCode.WARNINGS,
+            'method': 'UI.PerformInteraction',
+            'message': 'Unsupported ' + this.errorResponsePull[requestID].type 
+                + ' type. Available data in request was processed.'
           }
-        };
+        }
+
+        if (manualTextEntry) {
+          json.result.manualTextEntry = manualTextEntry
+        }
+
         if (commandID) {
-          JSONMessage.error.data.choiceID = commandID;
+          json.result.choiceID = commandID;
         }
-        if (manualTextEntry != null) {
-          JSONMessage.error.data.manualTextEntry = manualTextEntry;
-        }
-        this.client.send(JSONMessage);
+
+        this.client.send(json);
         this.errorResponsePull[requestID] = null;
         return;
       }

--- a/ffw/UIRPC.js
+++ b/ffw/UIRPC.js
@@ -1239,7 +1239,7 @@ FFW.UI = FFW.RPCObserver.create(
           'result': {
             'code': SDL.SDLModel.data.resultCode.WARNINGS,
             'method': 'UI.PerformInteraction',
-            'message': 'Unsupported ' + this.errorResponsePull[requestID].type 
+            'info': 'Unsupported ' + this.errorResponsePull[requestID].type 
                 + ' type. Available data in request was processed.'
           }
         }


### PR DESCRIPTION
the unsupported resource code from having an unsupported image type was preventing useful information from reaching mobile, when an interaction succeeds, we should send the command ID and proceed with WARNINGS and an info string

Implements/Fixes #222 

This PR is **ready** for review.

### Testing Plan
manually

### Summary
When an interaction succeeds, but also has an error associated with an unsupported imageType or SpeechCapabilities type, send a success response with code WARNINGS and a helpful info string.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
