### PR TITLE
vr perform interaction responds!

### DIFF
--- a/app/model/sdl/Abstract/Model.js
+++ b/app/model/sdl/Abstract/Model.js
@@ -1120,9 +1120,6 @@ SDL.SDLModel = Em.Object.extend({
 
     if (!SDL.SDLController.getApplicationModel(message.params.appID
       ).activeRequests.uiPerformInteraction) {
-      SDL.SDLController.getApplicationModel(message.params.appID
-      ).activeRequests.uiPerformInteraction = message.id;
-
       if (message.params && message.params.vrHelpTitle &&
         message.params.vrHelp) {
 
@@ -1131,6 +1128,17 @@ SDL.SDLModel = Em.Object.extend({
         );
         SDL.SDLModel.data.set('interactionData.vrHelp', message.params.vrHelp);
       }
+
+      SDL.InteractionChoicesView.cancelID = message.params.cancelID;
+
+      if (message.params && message.params.choiceSet == null) {
+        FFW.UI.sendUIResult(SDL.SDLModel.data.resultCode.SUCCESS, 
+          message.id, 'UI.PerformInteraction');
+        return true;
+      }
+
+      SDL.SDLController.getApplicationModel(message.params.appID)
+        .activeRequests.uiPerformInteraction = message.id;
 
       SDL.InteractionChoicesView.activate(message);
       SDL.SDLController.VRMove();

--- a/app/view/sdl/shared/interactionChoicesView.js
+++ b/app/view/sdl/shared/interactionChoicesView.js
@@ -171,7 +171,6 @@ SDL.InteractionChoicesView = SDL.SDLAbstractView.create(
         this.set('caption', message.params.initialText.fieldText);
       }
       this.appID = message.params.appID;
-      this.cancelID = message.params.cancelID;
       if (message.params.interactionLayout) {
         switch (message.params.interactionLayout) {
           case 'ICON_ONLY' :


### PR DESCRIPTION
Implements/Fixes #214 

This PR is **ready** for review.

### Testing Plan
manually

### Summary
Now, when a `VR_ONLY` perform interaction is received by the HMI, it will return `SUCCESS` to the `UI.PerformInteraction` RPC once it has populated the `interactionData.vrHelpTitle` and `interactionData.vrHelp` fields.

Additionally, since we will be bailing early on `uiPerformInteraction()`, I moved the assigning of `InteractionChoicesView.cancelID` so that it will be still be assigned in the case of a `VR_ONLY` interaction.

Lastly, `activeRequests.uiPerformInteraction` will not be populated when the interaction is `VR_ONLY`.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
