### PR TITLE
remove textFields that are unused and missing from mobile api

### DIFF
--- a/capabilities/display_capabilities.js
+++ b/capabilities/display_capabilities.js
@@ -94,12 +94,6 @@ SDL.templateCapabilities = {
                     "rows": 1
                 },
                 {
-                    "name": "navigationText",
-                    "characterSet": "TYPE2SET",
-                    "width": 500,
-                    "rows": 1
-                },
-                {
                     "name": "audioPassThruDisplayText1",
                     "characterSet": "TYPE2SET",
                     "width": 500,
@@ -124,12 +118,6 @@ SDL.templateCapabilities = {
                     "rows": 1
                 },
                 {
-                    "name": "notificationText",
-                    "characterSet": "TYPE2SET",
-                    "width": 500,
-                    "rows": 1
-                },
-                {
                     "name": "menuName",
                     "characterSet": "TYPE2SET",
                     "width": 500,
@@ -143,12 +131,6 @@ SDL.templateCapabilities = {
                 },
                 {
                     "name": "tertiaryText",
-                    "characterSet": "TYPE2SET",
-                    "width": 500,
-                    "rows": 1
-                },
-                {
-                    "name": "timeToDestination",
                     "characterSet": "TYPE2SET",
                     "width": 500,
                     "rows": 1
@@ -547,12 +529,6 @@ SDL.templateCapabilities = {
                     "rows": 1
                 },
                 {
-                    "name": "navigationText",
-                    "characterSet": "TYPE2SET",
-                    "width": 500,
-                    "rows": 1
-                },
-                {
                     "name": "audioPassThruDisplayText1",
                     "characterSet": "TYPE2SET",
                     "width": 500,
@@ -577,12 +553,6 @@ SDL.templateCapabilities = {
                     "rows": 1
                 },
                 {
-                    "name": "notificationText",
-                    "characterSet": "TYPE2SET",
-                    "width": 500,
-                    "rows": 1
-                },
-                {
                     "name": "menuName",
                     "characterSet": "TYPE2SET",
                     "width": 500,
@@ -596,12 +566,6 @@ SDL.templateCapabilities = {
                 },
                 {
                     "name": "tertiaryText",
-                    "characterSet": "TYPE2SET",
-                    "width": 500,
-                    "rows": 1
-                },
-                {
-                    "name": "timeToDestination",
                     "characterSet": "TYPE2SET",
                     "width": 500,
                     "rows": 1
@@ -1007,12 +971,6 @@ SDL.templateCapabilities = {
                     "rows": 1
                 },
                 {
-                    "name": "navigationText",
-                    "characterSet": "TYPE2SET",
-                    "width": 500,
-                    "rows": 1
-                },
-                {
                     "name": "audioPassThruDisplayText1",
                     "characterSet": "TYPE2SET",
                     "width": 500,
@@ -1050,12 +1008,6 @@ SDL.templateCapabilities = {
                 },
                 {
                     "name": "tertiaryText",
-                    "characterSet": "TYPE2SET",
-                    "width": 500,
-                    "rows": 1
-                },
-                {
-                    "name": "timeToDestination",
                     "characterSet": "TYPE2SET",
                     "width": 500,
                     "rows": 1
@@ -1461,12 +1413,6 @@ SDL.templateCapabilities = {
                     "rows": 1
                 },
                 {
-                    "name": "navigationText",
-                    "characterSet": "TYPE2SET",
-                    "width": 500,
-                    "rows": 1
-                },
-                {
                     "name": "audioPassThruDisplayText1",
                     "characterSet": "TYPE2SET",
                     "width": 500,
@@ -1491,12 +1437,6 @@ SDL.templateCapabilities = {
                     "rows": 1
                 },
                 {
-                    "name": "notificationText",
-                    "characterSet": "TYPE2SET",
-                    "width": 500,
-                    "rows": 1
-                },
-                {
                     "name": "menuName",
                     "characterSet": "TYPE2SET",
                     "width": 500,
@@ -1510,12 +1450,6 @@ SDL.templateCapabilities = {
                 },
                 {
                     "name": "tertiaryText",
-                    "characterSet": "TYPE2SET",
-                    "width": 500,
-                    "rows": 1
-                },
-                {
-                    "name": "timeToDestination",
                     "characterSet": "TYPE2SET",
                     "width": 500,
                     "rows": 1

--- a/capabilities/display_capabilities.js
+++ b/capabilities/display_capabilities.js
@@ -154,12 +154,6 @@ SDL.templateCapabilities = {
                     "rows": 1
                 },
                 {
-                    "name": "turnText",
-                    "characterSet": "TYPE2SET",
-                    "width": 500,
-                    "rows": 1
-                },
-                {
                     "name": "menuTitle",
                     "characterSet": "TYPE2SET",
                     "width": 500,
@@ -613,12 +607,6 @@ SDL.templateCapabilities = {
                     "rows": 1
                 },
                 {
-                    "name": "turnText",
-                    "characterSet": "TYPE2SET",
-                    "width": 500,
-                    "rows": 1
-                },
-                {
                     "name": "menuTitle",
                     "characterSet": "TYPE2SET",
                     "width": 500,
@@ -1049,12 +1037,6 @@ SDL.templateCapabilities = {
                     "rows": 1
                 },
                 {
-                    "name": "notificationText",
-                    "characterSet": "TYPE2SET",
-                    "width": 500,
-                    "rows": 1
-                },
-                {
                     "name": "menuName",
                     "characterSet": "TYPE2SET",
                     "width": 500,
@@ -1074,12 +1056,6 @@ SDL.templateCapabilities = {
                 },
                 {
                     "name": "timeToDestination",
-                    "characterSet": "TYPE2SET",
-                    "width": 500,
-                    "rows": 1
-                },
-                {
-                    "name": "turnText",
                     "characterSet": "TYPE2SET",
                     "width": 500,
                     "rows": 1
@@ -1540,12 +1516,6 @@ SDL.templateCapabilities = {
                 },
                 {
                     "name": "timeToDestination",
-                    "characterSet": "TYPE2SET",
-                    "width": 500,
-                    "rows": 1
-                },
-                {
-                    "name": "turnText",
                     "characterSet": "TYPE2SET",
                     "width": 500,
                     "rows": 1

--- a/ffw/UIRPC.js
+++ b/ffw/UIRPC.js
@@ -636,12 +636,6 @@ FFW.UI = FFW.RPCObserver.create(
                       'rows': 1
                     },
                     {
-                      'name': 'navigationText',
-                      'characterSet': 'TYPE2SET',
-                      'width': 500,
-                      'rows': 1
-                    },
-                    {
                       'name': 'audioPassThruDisplayText1',
                       'characterSet': 'TYPE2SET',
                       'width': 500,
@@ -679,12 +673,6 @@ FFW.UI = FFW.RPCObserver.create(
                     },
                     {
                       'name': 'tertiaryText',
-                      'characterSet': 'TYPE2SET',
-                      'width': 500,
-                      'rows': 1
-                    },
-                    {
-                      'name': 'timeToDestination',
                       'characterSet': 'TYPE2SET',
                       'width': 500,
                       'rows': 1

--- a/ffw/UIRPC.js
+++ b/ffw/UIRPC.js
@@ -666,12 +666,6 @@ FFW.UI = FFW.RPCObserver.create(
                       'rows': 1
                     },
                     {
-                      'name': 'notificationText',
-                      'characterSet': 'TYPE2SET',
-                      'width': 500,
-                      'rows': 1
-                    },
-                    {
                       'name': 'menuName',
                       'characterSet': 'TYPE2SET',
                       'width': 500,
@@ -691,12 +685,6 @@ FFW.UI = FFW.RPCObserver.create(
                     },
                     {
                       'name': 'timeToDestination',
-                      'characterSet': 'TYPE2SET',
-                      'width': 500,
-                      'rows': 1
-                    },
-                    {
-                      'name': 'turnText',
                       'characterSet': 'TYPE2SET',
                       'width': 500,
                       'rows': 1


### PR DESCRIPTION
Partially Fixes #215 

This PR is **ready** for review.

### Testing Plan
manual testing

### Summary
Remove unused TextFields `turnText` and `notificationText` from the display capabilities of the hmi. Other fields causing the issue in #215 are `navigationText` and `timeToDestination` which are used but are not present in the mobile api.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
