### PR TITLE
Fix syntax error in SettingsController.js

### DIFF
--- a/app/controller/SettingsController.js
+++ b/app/controller/SettingsController.js
@@ -439,7 +439,7 @@ SDL.SettingsController = Em.Object.create(
         nestedProperty: 'custom_vehicle_data_mapping_url'
       };
       FFW.BasicCommunication.GetPolicyConfigurationData(policyConfigurationData);
-    }
+    },
     
     /**
      * @function changeGetSystemTimeResultCode


### PR DESCRIPTION

This PR is **ready** for review.

### Summary
Fixes syntax error in SettingsController.js

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
