### PR TITLE
remove unsupported static icons from alertIcon param

### DIFF
--- a/ffw/RPCObserver.js
+++ b/ffw/RPCObserver.js
@@ -103,6 +103,15 @@ FFW.RPCObserver = Em.Object.extend(
             params.image.value = params.image.value + '?m=' + new Date().getTime();
           }
         }
+        if ('alertIcon' in params) {
+          if (params.alertIcon.imageType === 'STATIC') {
+            delete params.alertIcon;
+            return false;
+          } else {
+            params.alertIcon.value = params.alertIcon.value.replace(/\\/g, '%5C');
+            params.alertIcon.value = params.alertIcon.value + '?m=' + new Date().getTime();
+          }
+        }
         if ('secondaryImage' in params) {
           if (params.secondaryImage.imageType === 'STATIC') {
             delete params.secondaryImage;


### PR DESCRIPTION
Fixes an issue found during regression testing.
The HMI will attempt to render a static icon when sent in the `alertIcon` parameter even though the HMI does not support static icons.

This PR is **ready** for review.

### Testing Plan
Manual testing, android test suite

### Summary
add case to `checkImage` function for the `alertIcon` parameter

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
