### PR TITLE
Add removed OnSystemRequestHandler function

### DIFF
--- a/app/controller/SettingsController.js
+++ b/app/controller/SettingsController.js
@@ -308,6 +308,22 @@ SDL.SettingsController = Em.Object.create(
         ].isSDLAllowed = result;
       SDL.SettingsController.currentDeviceAllowance = null;
     },
+
+    OnSystemRequestHandler: function(url) {
+      if(FLAGS.ExternalPolicies === true) {
+        FFW.ExternalPolicies.pack({
+          type: 'PROPRIETARY',
+          policyUpdateFile: SDL.SettingsController.policyUpdateFile,
+          url: url
+        })
+      } else {
+        FFW.BasicCommunication.OnSystemRequest(
+          'PROPRIETARY',
+          SDL.SettingsController.policyUpdateFile,
+          url
+        );
+      }
+    },
     /**
      * Method to check Array of GetUrls data
      * And verify what OnSystemRequest should be sent


### PR DESCRIPTION
Fixes js exception on policy table update

This PR is **[ready]** for review.

### Summary
After  the mergre of https://github.com/smartdevicelink/sdl_hmi/pull/216, `OnSystemRequestHandler` function was removed, but still called in `onRPCResult`, which resulted in js exception. This PR adds this function back. 

### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
