### PR TITLE
Fix init function for LightModel

### DIFF
--- a/app/model/LightModel.js
+++ b/app/model/LightModel.js
@@ -146,6 +146,7 @@ SDL.LightModel = Em.Object.extend({
                 state.push(tempState);
             }
         }
+        this.lightState = [];
         initialization(this.singleLightNameStruct, this.lightState);
         initialization(this.exteriorLightNameStruct, this.lightState);
         initialization(this.interiorLightNameStruct, this.lightState);


### PR DESCRIPTION
Fix for issue with merge of #216 

This PR is **ready** for review.

### Summary
It seems that ember objects keep the same state between `create()` calls, which was causing the lightState array to grow each time a new LightModel was created. This clears the lightState array before initialization

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
