### PR TITLE
Enable vehicle emulation by default

### DIFF
--- a/app/Flags.js
+++ b/app/Flags.js
@@ -68,11 +68,11 @@ FLAGS = Em.Object.create(
      * 'vehicle_2x3' - emulate 2x3 one level vehicle
      * 'vehicle_3x3' - emulate 3x3 one level vehicle
      */
-    VehicleEmulationType: 'no_emulation',
+    VehicleEmulationType: 'vehicle_2x3',
 
     /**
      * Flag for storing last applied vehicle emulation type
      */
-    lastVehicleEmulationtype: 'no_emulation'
+    lastVehicleEmulationtype: 'vehicle_2x3'
   }
 );


### PR DESCRIPTION
Implements/Fixes #240 

This PR is **ready** for review.

### Testing Plan
Covered by manual testing checklist

### Summary
After including of feature "[SDL 0221] Remote Control - Allow Multiple Modules per Module Type" into the release 6.0, new SDL is now working with the `SystemCapabilities` with included `moduleId` mandatory field. However, `no emulation` mode on HMI was designed to test older SDL versions which are not supporting this feature and working without `moduleId`.

In order to make latest HMI to be on the same page with SDL, emulation mode has been enabled by default. This simplifies work with HMI as tester does not need to change emulation mode each time on each HMI start. It makes more sense to disable emulation when it is not needed, but by default it
should be enabled for the latest releases.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
