### PR TITLE
Set Duplicated Widget Content on CreateWindow

### DIFF
--- a/app/model/sdl/Abstract/AppModel.js
+++ b/app/model/sdl/Abstract/AppModel.js
@@ -679,13 +679,8 @@ SDL.ABSAppModel = Em.Object.extend(
         }) : null ;
 
         content["showStrings"] = showStringsArray;    
-
-        var softButtonsArray = this.get("softButtons");
-        if (softButtonsArray.length > 4) {
-          softButtonsArray.length = 4;
-        }
         
-        content["softButtons"] = softButtonsArray;
+        content["softButtons"] = this.get("softButtons").slice(0,4);
 
         if (SDL.SDLController.model.appInfo.mainImage) {
           content["graphic"] = {
@@ -833,9 +828,6 @@ SDL.ABSAppModel = Em.Object.extend(
           params.showStrings.length = masStringsToShow;
         }
         let currentTemplateConfiguation = element.content.templateConfiguration;
-        if (!element.content) {
-          element["content"] = {}
-        }
         if (!element.content.showStrings) {
           element['content']['showStrings'] = params.showStrings;
         } else {
@@ -890,7 +882,7 @@ SDL.ABSAppModel = Em.Object.extend(
 
       this.inactiveWindows.forEach(element => {
         let windowID = getWindowIDToApplyShow(params, element);
-        if(windowID !== null) {
+        if(windowID) {
           setElementsToShow(element);
           SDL.RightSideView.getWidgetContainer().updateWidgetContent(this, windowID);
         }
@@ -898,7 +890,7 @@ SDL.ABSAppModel = Em.Object.extend(
 
       this.backgroundWindows.forEach(element => {
         let windowID = getWindowIDToApplyShow(params, element);
-        if(windowID !== null) {
+        if(windowID) {
           setElementsToShow(element);
           SDL.RightSideView.getWidgetContainer().updateWidgetContent(this, windowID);
         }
@@ -906,7 +898,7 @@ SDL.ABSAppModel = Em.Object.extend(
 
       this.activeWindows.forEach(element => {
         let windowID = getWindowIDToApplyShow(params, element);
-        if(windowID !== null) {
+        if(windowID) {
           setElementsToShow(element);
           SDL.RightSideView.getWidgetContainer().updateWidgetContent(this, windowID);
         }

--- a/app/model/sdl/Abstract/AppModel.js
+++ b/app/model/sdl/Abstract/AppModel.js
@@ -678,8 +678,27 @@ SDL.ABSAppModel = Em.Object.extend(
           "fieldText": SDL.SDLController.model.appInfo.field2
         }) : null ;
 
-        content["showStrings"] = showStringsArray;       
+        content["showStrings"] = showStringsArray;    
+
+        var softButtonsArray = this.get("softButtons");
+        if (softButtonsArray.length > 4) {
+          softButtonsArray.length = 4;
+        }
+        
+        content["softButtons"] = softButtonsArray;
+
+        if (SDL.SDLController.model.appInfo.mainImage) {
+          content["graphic"] = {
+            "value" : SDL.SDLController.model.appInfo.mainImage
+          };
+        } else if (SDL.SDLController.model.appInfo.trackIcon) {
+          content["graphic"] = {
+            "value" : SDL.SDLController.model.appInfo.trackIcon
+          };
+        }
+
         content["templateConfiguration"] = this.templateConfiguration;
+
         windowParam.content = content;
       } else if (windowParam.duplicateUpdatesFromWindowID && windowParam.duplicateUpdatesFromWindowID > 0) {
         var duplicateWindowID = windowParam.duplicateUpdatesFromWindowID;

--- a/app/model/sdl/Abstract/AppModel.js
+++ b/app/model/sdl/Abstract/AppModel.js
@@ -665,7 +665,30 @@ SDL.ABSAppModel = Em.Object.extend(
      * @description Called after receiving CreateWindow request 
      */
     createWindow: function(windowParam) {
-      windowParam.content = {"templateConfiguration" : this.defaultTemplateConfiguration};
+      var content = {};
+      if (windowParam.duplicateUpdatesFromWindowID === 0) {
+        var showStringsArray = [];
+        SDL.SDLController.model.appInfo.field1 ? showStringsArray.push({
+          "fieldName": "mainField1",
+          "fieldText": SDL.SDLController.model.appInfo.field1
+        }) : null ;
+
+        SDL.SDLController.model.appInfo.field2 ? showStringsArray.push({
+          "fieldName": "mainField2",
+          "fieldText": SDL.SDLController.model.appInfo.field2
+        }) : null ;
+
+        content["showStrings"] = showStringsArray;       
+        content["templateConfiguration"] = this.templateConfiguration;
+        windowParam.content = content;
+      } else if (windowParam.duplicateUpdatesFromWindowID && windowParam.duplicateUpdatesFromWindowID > 0) {
+        var duplicateWindowID = windowParam.duplicateUpdatesFromWindowID;
+        var modelToDuplicate = this.getWidgetModel(duplicateWindowID);
+        windowParam.content = modelToDuplicate.content ? modelToDuplicate.content : 
+                                {"templateConfiguration" : this.defaultTemplateConfiguration};
+      } else {
+        windowParam.content = {"templateConfiguration" : this.defaultTemplateConfiguration};
+      }
       this.inactiveWindows.push(windowParam);
     },
 
@@ -791,8 +814,32 @@ SDL.ABSAppModel = Em.Object.extend(
           params.showStrings.length = masStringsToShow;
         }
         let currentTemplateConfiguation = element.content.templateConfiguration;
-        element['content'] = {};
-        element['content']['showStrings'] = params.showStrings;
+        if (!element.content) {
+          element["content"] = {}
+        }
+        if (!element.content.showStrings) {
+          element['content']['showStrings'] = params.showStrings;
+        } else {
+          var mergedShowStrings = [];
+          // Deep Copy
+          element.content.showStrings.forEach(function(value, index, array) {
+            mergedShowStrings.push(value);
+          });
+          // Merge existing show strings with new show request
+          for(var i=0; i<params.showStrings.length; i++) {
+            for (var j=0; j<mergedShowStrings.length; j++) {
+              var newField = params.showStrings[i];
+              var existingField = mergedShowStrings[i];
+              if (newField.fieldName === existingField.fieldName) {
+                mergedShowStrings[i].fieldText = newField.fieldText;
+              } else {
+                mergedShowStrings.push(newField);
+              }
+            }
+          }
+          element.content.showStrings = mergedShowStrings;
+        }
+        
         if('softButtons' in params) {
           var maxSoftButtonsToShow = 4;
           if(maxSoftButtonsToShow < params.softButtons.length) {
@@ -821,6 +868,14 @@ SDL.ABSAppModel = Em.Object.extend(
 
         return null;
       };
+
+      this.inactiveWindows.forEach(element => {
+        let windowID = getWindowIDToApplyShow(params, element);
+        if(windowID !== null) {
+          setElementsToShow(element);
+          SDL.RightSideView.getWidgetContainer().updateWidgetContent(this, windowID);
+        }
+      });
 
       this.backgroundWindows.forEach(element => {
         let windowID = getWindowIDToApplyShow(params, element);


### PR DESCRIPTION
Fixes #247 

This PR is **ready** for review.

### Testing Plan
- Send show to main window with mainfield 1 and 2 populated.
- Send CreateWindow with duplicateUpdatesFromWindowID = 0
- Activate widget and make sure that its contents match that of the main window.

### Summary
- On CreateWindow with param duplicateUpdatesFromWindowID, find existing show information and add to newly created widgets content.
- Update widgetShow function to merge incoming show strings with existing fields instead of overwriting. 
- Apply show to inactive widget windows to prevent duplicated widget windows from missing show requests to the windows they are duplicating from.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
