### PR TITLE
h264 over RTP

### DIFF
--- a/capabilities/systemCapabilities.js
+++ b/capabilities/systemCapabilities.js
@@ -43,27 +43,22 @@ SDL.systemCapabilities =
             {
                 protocol:  "RAW",
                 codec: "H264"
-                
             },
             {
                 protocol:  "RTP",
-                codec: "H265"
-                
+                codec: "H264"
             },
             {
                 protocol:  "RTSP",
                 codec: "Theora"
-                
             },
             {
                 protocol:  "RTMP",
                 codec: "VP8"
-                
             },
             {
                 protocol:  "WEBM",
                 codec: "VP9"
-                
             }
         ],
         hapticSpatialDataSupported: true,

--- a/ffw/NavigationRPC.js
+++ b/ffw/NavigationRPC.js
@@ -421,15 +421,18 @@ FFW.Navigation = FFW.RPCObserver.create(
           case 'Navigation.SetVideoConfig':
           {
             var rejectedParams = [];
+            var video_formats = SDL.systemCapabilities.videoStreamingCapability.supportedFormats;
             if ('protocol' in request.params.config) {
-              if (request.params.config.protocol != 'RAW') {
+              video_formats = video_formats.filter(x => x.protocol === request.params.config.protocol);
+              if (video_formats.length === 0) {
                 Em.Logger.log('FFW.' + request.method + ' rejects protocol: '
                               + request.params.config.protocol);
                 rejectedParams.push('protocol');
               }
             }
-            if ('codec' in request.params.config) {
-              if (request.params.config.codec != 'H264') {
+            if ('codec' in request.params.config && video_formats.length > 0) {
+              video_formats = video_formats.filter(x => x.codec === request.params.config.codec);
+              if (video_formats.length === 0) {
                 Em.Logger.log('FFW.' + request.method + ' rejects codec: '
                               + request.params.config.codec);
                 rejectedParams.push('codec');


### PR DESCRIPTION
This PR is **ready** for review.

### Testing Plan
Manual Testing

### Summary
Update `systemCapabilities.js` to use H264 over RTP as suggested in the Core Guides and as is implemented in the mobile libraries.

### Tasks Remaining
- [x] Update `NavigationRPC.js` to check if protocol is supported in the `systemCapabilities`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
