### PR TITLE
Fix/double send of on language change and on systeminfo changed

### DIFF
--- a/app/controller/sdl/Abstract/Controller.js
+++ b/app/controller/sdl/Abstract/Controller.js
@@ -875,15 +875,30 @@ SDL.SDLController = Em.Object.extend(
       );
       FFW.UI.performAudioPassThruRequestID = -1;
     },
+
+    /**
+     * Language change counter
+     */
+    languageChangeCount: 0,
+    canNotifyOnLanguageChange: function() {
+      if (this.languageChangeCount < 1) {
+        this.languageChangeCount += 1;
+        return true;
+      } else {
+        this.languageChangeCount = 0;
+        return false;
+      }
+    },
     /**
      * Method to set language for UI component with parameters sent from
      * SDLCore to UIRPC
      */
     onLanguageChangeUI: function() {
+      if (!this.canNotifyOnLanguageChange()) {
+        return;
+      }
       FFW.UI.OnLanguageChange(SDL.SDLModel.data.hmiUILanguage);
-      FFW.BasicCommunication.OnSystemInfoChanged(
-        SDL.SDLModel.data.hmiUILanguage
-      );
+      FFW.BasicCommunication.OnSystemInfoChanged(SDL.SDLModel.data.hmiUILanguage);
     }.observes('SDL.SDLModel.data.hmiUILanguage'),
     /**
      * Method to set language for TTS and VR components with parameters sent

--- a/app/controller/sdl/Abstract/Controller.js
+++ b/app/controller/sdl/Abstract/Controller.js
@@ -875,67 +875,22 @@ SDL.SDLController = Em.Object.extend(
       );
       FFW.UI.performAudioPassThruRequestID = -1;
     },
-
-    /**
-     * UI language change counter
-     */
-    uiLangChangeCount: 0,
-    /**
-     * VR/TTS language change counter
-     */
-    vrLangChangeCount: 0,
-
-    /**
-     * Method to define how much times langChange was called.
-     * It is known bug in Ember: if observer subscribed to view field
-     * item-changed event is sent twice.
-     * We need only one notification per time
-     */
-    canNotifyOnLanguageChange: function(langType) {
-      switch (langType) {
-        case "UI":
-          if (this.uiLangChangeCount < 1) {
-            this.uiLangChangeCount += 1;
-            return true;
-          } else {
-            this.uiLangChangeCount = 0;
-            return false;
-          }
-        break;
-        
-        case "VR":
-          if (this.vrLangChangeCount < 1) {
-            this.vrLangChangeCount += 1;
-            return true;
-          } else {
-            this.vrLangChangeCount = 0;
-            return false;
-          }
-        break;
-      }
-    },
     /**
      * Method to set language for UI component with parameters sent from
      * SDLCore to UIRPC
      */
-    onLanguageChangeUI: function() {
-      if (!this.canNotifyOnLanguageChange("UI")) {
-        return;
-      }
-      FFW.UI.OnLanguageChange(SDL.SDLModel.data.hmiUILanguage);
-      FFW.BasicCommunication.OnSystemInfoChanged(SDL.SDLModel.data.hmiUILanguage);
-    }.observes('SDL.SDLModel.data.hmiUILanguage'),
+    onLanguageChangeUI: function(newLanguage) {
+      FFW.UI.OnLanguageChange(newLanguage);
+      FFW.BasicCommunication.OnSystemInfoChanged(newLanguage);
+    },
     /**
      * Method to set language for TTS and VR components with parameters sent
      * from SDLCore to UIRPC
      */
-    onLanguageChangeTTSVR: function() {
-      if (!this.canNotifyOnLanguageChange("VR")) {
-        return;
-      }
-      FFW.TTS.OnLanguageChange(SDL.SDLModel.data.hmiTTSVRLanguage);
-      FFW.VR.OnLanguageChange(SDL.SDLModel.data.hmiTTSVRLanguage);
-    }.observes('SDL.SDLModel.data.hmiTTSVRLanguage'),
+    onLanguageChangeTTSVR: function(newLanguage) {
+      FFW.TTS.OnLanguageChange(newLanguage);
+      FFW.VR.OnLanguageChange(newLanguage);
+    },
     /**
      * Register application
      *

--- a/app/controller/sdl/Abstract/Controller.js
+++ b/app/controller/sdl/Abstract/Controller.js
@@ -877,16 +877,41 @@ SDL.SDLController = Em.Object.extend(
     },
 
     /**
-     * Language change counter
+     * UI language change counter
      */
-    languageChangeCount: 0,
-    canNotifyOnLanguageChange: function() {
-      if (this.languageChangeCount < 1) {
-        this.languageChangeCount += 1;
-        return true;
-      } else {
-        this.languageChangeCount = 0;
-        return false;
+    uiLangChangeCount: 0,
+    /**
+     * VR/TTS language change counter
+     */
+    vrLangChangeCount: 0,
+
+    /**
+     * Method to define how much times langChange was called.
+     * It is known bug in Ember: if observer subscribed to view field
+     * item-changed event is sent twice.
+     * We need only one notification per time
+     */
+    canNotifyOnLanguageChange: function(langType) {
+      switch (langType) {
+        case "UI":
+          if (this.uiLangChangeCount < 1) {
+            this.uiLangChangeCount += 1;
+            return true;
+          } else {
+            this.uiLangChangeCount = 0;
+            return false;
+          }
+        break;
+        
+        case "VR":
+          if (this.vrLangChangeCount < 1) {
+            this.vrLangChangeCount += 1;
+            return true;
+          } else {
+            this.vrLangChangeCount = 0;
+            return false;
+          }
+        break;
       }
     },
     /**
@@ -894,7 +919,7 @@ SDL.SDLController = Em.Object.extend(
      * SDLCore to UIRPC
      */
     onLanguageChangeUI: function() {
-      if (!this.canNotifyOnLanguageChange()) {
+      if (!this.canNotifyOnLanguageChange("UI")) {
         return;
       }
       FFW.UI.OnLanguageChange(SDL.SDLModel.data.hmiUILanguage);
@@ -905,6 +930,9 @@ SDL.SDLController = Em.Object.extend(
      * from SDLCore to UIRPC
      */
     onLanguageChangeTTSVR: function() {
+      if (!this.canNotifyOnLanguageChange("VR")) {
+        return;
+      }
       FFW.TTS.OnLanguageChange(SDL.SDLModel.data.hmiTTSVRLanguage);
       FFW.VR.OnLanguageChange(SDL.SDLModel.data.hmiTTSVRLanguage);
     }.observes('SDL.SDLModel.data.hmiTTSVRLanguage'),

--- a/app/view/home/controlButtons.js
+++ b/app/view/home/controlButtons.js
@@ -284,7 +284,11 @@ getCurrentDisplayModeClass: function() {
 
     contentBinding: 'SDL.SDLModel.data.sdlLanguagesList',
 
-    valueBinding: 'SDL.SDLModel.data.hmiUILanguage'
+    valueBinding: 'SDL.SDLModel.data.hmiUILanguage',
+
+    change: function() {
+      SDL.SDLController.onLanguageChangeUI(this.selection);
+    }
   }
 ),
 
@@ -300,7 +304,11 @@ getCurrentDisplayModeClass: function() {
 
     contentBinding: 'SDL.SDLModel.data.sdlLanguagesList',
 
-    valueBinding: 'SDL.SDLModel.data.hmiTTSVRLanguage'
+    valueBinding: 'SDL.SDLModel.data.hmiTTSVRLanguage',
+
+    change: function() {
+      SDL.SDLController.onLanguageChangeTTSVR(this.selection);
+    }
   }
 ),
 


### PR DESCRIPTION
Fixes #256 

This PR is **ready** for review.

### Testing Plan
Manual testing by steps described in #256 

### Summary
There is known bug in old version of Ember.js (specifically 1.0, which is currently used) - observers of _SelectView_ item are noticed twice per each event. That is why `OnLanguageChanged` and `OnSystemInfoChanged` notifications come twice.
Implemented simple mechanism of blocking second notifications sending.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
