### PR TITLE
fix crash with merging widget show strings

### DIFF
--- a/app/model/sdl/Abstract/AppModel.js
+++ b/app/model/sdl/Abstract/AppModel.js
@@ -838,14 +838,13 @@ SDL.ABSAppModel = Em.Object.extend(
           });
           // Merge existing show strings with new show request
           for(var i=0; i<params.showStrings.length; i++) {
-            for (var j=0; j<mergedShowStrings.length; j++) {
-              var newField = params.showStrings[i];
-              var existingField = mergedShowStrings[i];
-              if (newField.fieldName === existingField.fieldName) {
-                mergedShowStrings[i].fieldText = newField.fieldText;
-              } else {
-                mergedShowStrings.push(newField);
-              }
+            var newField = params.showStrings[i];
+            var existingField = mergedShowStrings.find(oldField => oldField.fieldName == newField.fieldName);
+
+            if (existingField) {
+              existingField.fieldText = newField.fieldText;
+            } else {
+              mergedShowStrings.push(newField);
             }
           }
           element.content.showStrings = mergedShowStrings;


### PR DESCRIPTION
Fixed #281

This PR is **ready** for review.

### Testing Plan
Follow the reproduction steps from the issue and see that the browser does not run out of memory but instead quickly displays the new show.

### Summary
Only do `mergedShowStrings.push(newField);` if it `newField.fieldName` does not match that of any existing fields.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
