### PR TITLE
Fix miscellaneous vehicle info model issues

### DIFF
--- a/app/model/sdl/VehicleInfoModel.js
+++ b/app/model/sdl/VehicleInfoModel.js
@@ -415,7 +415,9 @@ SDL.SDLVehicleInfoModel = Em.Object.create(
         else if (subscriptions[key].resultCode == 'VEHICLE_DATA_NOT_AVAILABLE') {
           code = SDL.SDLModel.data.resultCode.DATA_NOT_AVAILABLE;
         }
-        else if (code == SDL.SDLModel.data.resultCode.SUCCESS && subscriptions[key].resultCode == 'DATA_ALREADY_SUBSCRIBED') {
+        else if (code == SDL.SDLModel.data.resultCode.SUCCESS && 
+            (subscriptions[key].resultCode == 'DATA_ALREADY_SUBSCRIBED' || 
+             subscriptions[key].resultCode == 'DATA_NOT_SUBSCRIBED' ) {
           code = SDL.SDLModel.data.resultCode.IGNORED;
         }
       }


### PR DESCRIPTION

This PR is **ready** for review.

### Testing Plan
Test `GetVehicleData("emergencyEvent")` and `GetVehicleData("speed")`, verify that both cases work with the default model.
Remove a vehicle data item from the Vehicle Info model and request a subscription to that item via `SubscribeVehicleData`, verify that a `DATA_NOT_AVAILABLE` response is received
Request a subscription to a previously subscribed item via `SubscribeVehicleData`, verify that a `IGNORED` response is received


### Summary
Fix issue where GetVehicleData would not work if the value of the requested data was 0
Fix issue where `maximumChangeVelocity` was populated with the incorrect data type
Fix incorrect error message if specific vehicle data is not available

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
