### PR TITLE
Deactivate tts before responding to alert

### DIFF
--- a/ffw/UIRPC.js
+++ b/ffw/UIRPC.js
@@ -1651,7 +1651,9 @@ FFW.UI = FFW.RPCObserver.create(
         case SDL.SDLModel.data.resultCode.WARNINGS:
         case SDL.SDLModel.data.resultCode.SUCCESS:
         {
-          SDL.TTSPopUp.DeactivateTTS();
+          if (SDL.TTSPopUp.active) {
+            SDL.TTSPopUp.DeactivateTTS();
+          }
           this.sendUIResult(resultCode, id, 'UI.Alert', info);
           break;
         }

--- a/ffw/UIRPC.js
+++ b/ffw/UIRPC.js
@@ -1651,6 +1651,7 @@ FFW.UI = FFW.RPCObserver.create(
         case SDL.SDLModel.data.resultCode.WARNINGS:
         case SDL.SDLModel.data.resultCode.SUCCESS:
         {
+          SDL.TTSPopUp.DeactivateTTS();
           this.sendUIResult(resultCode, id, 'UI.Alert', info);
           break;
         }


### PR DESCRIPTION

This PR is **ready** for review.

### Testing Plan
Send an alert with tts chunks, and a 3 second duration

```
        Alert alert = new Alert();
        alert.setAlertText1("Hi there!");
        alert.setDuration(3000);

        TTSChunk textChunk = new TTSChunk();
        textChunk.setType(SpeechCapabilities.TEXT);
        textChunk.setText("HELLO TTS");
        List<TTSChunk> chunkList = Collections.singletonList(textChunk);

        alert.setTtsChunks(chunkList);
```

### Summary
Deactivates the tts popup before returning the alert response. Prevents unnecessary aborted response.

### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
