### PR TITLE
Point websocket-server sub module to smartdevicelink fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "python_websocket"]
 	path = python_websocket
-	url = https://github.com/Pithikos/python-websocket-server.git
+	url = https://github.com/smartdevicelink/python-websocket-server.git

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SDL HMI
 
-HTML5 based utility to see how the SDL works. It connects via WebSocket to [SDLCore](https://github.com/LuxoftSDL/sdl_core)
+HTML5 based utility to see how the SDL works. It connects via WebSocket to [SDL Core](https://github.com/smartdevicelink/sdl_core)
 
 # Getting Started
 A quick guide to installing, configuring, and running HMI.
@@ -24,7 +24,15 @@ In order to get policy table updates using the vehicle modem, some additional se
     4. Select the `PTU using in-vehicle modem` checkbox to enable the feature
 
 ## A quick note about dependencies
-All dependencies are installed after the SDL Core is successfully installed.
+This project interacts with [SDL Core](https://github.com/smartdevicelink/sdl_core).
+
+To initialize the git submodules in this project after cloning, run the following commands:
+```
+cd sdl_hmi
+git submodule init
+git submodule update
+```
+Alternatively, you can clone this repository with the --recurse-submodules flag.
 
 ## Note
 SDL HMI utility is only for acquaintance with the SDL project.


### PR DESCRIPTION
This PR is **ready** for review.

### Testing Plan
clone the sdl_hmi and ensure everything works as expected (especially web engine)

### Summary
Change location of submodule to a fork within the SDL org

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
