### PR TITLE
Fix/Add external policies client reconnection flow

### DIFF
--- a/app/view/settings/policies/connectionSettingsView.js
+++ b/app/view/settings/policies/connectionSettingsView.js
@@ -88,8 +88,8 @@ SDL.ConnectionSettingsView = Em.ContainerView.create(
           params: {
             action: 'changeUcsVehicle',
             target: 'SDL.SettingsController',
-            name: 'Disallow vehicle permissions',
-            text: 'Disallow vehicle permissions - ' + SDL.SDLModel.data.externalConsentStatus[1].status,
+            name: 'Allow vehicle permissions',
+            text: 'Allow vehicle permissions - ' + SDL.SDLModel.data.externalConsentStatus[1].status,
           }
         }
       );

--- a/ffw/ExternalPolicies.js
+++ b/ffw/ExternalPolicies.js
@@ -28,7 +28,11 @@ FFW.ExternalPolicies = Em.Object.create({
 
     packClient: null,
 
+    packClientURL: 'ws://127.0.0.1:8088',
+
     unpackClient: null,
+
+    unpackClientURL: 'ws://127.0.0.1:8089',
 
     packResponseReady: false,
 
@@ -36,15 +40,16 @@ FFW.ExternalPolicies = Em.Object.create({
 
     sysReqParams: {},
 
-    connect: function() {
-        this.packClient = new WebSocket('ws://127.0.0.1:8088');
-        this.unpackClient = new WebSocket('ws://127.0.0.1:8089');
+    createPackClient(){
+        this.packClient = new WebSocket(this.packClientURL);
         var self = this;
         this.packClient.onopen = function(evt) {
             self.onWSOpen(evt, this);
         };
         this.packClient.onclose = function(evt) {
             self.onWSClose(evt);
+            this.packClient = null;
+            setTimeout(() => { self.createPackClient(); }, 5000);
         };
         this.packClient.onmessage = function(evt) {
             self.onPackMessage(evt);
@@ -52,11 +57,18 @@ FFW.ExternalPolicies = Em.Object.create({
         this.packClient.onerror = function(evt) {
             self.onWSError(evt);
         };
+    },
+
+    createUnpackClient(){
+        this.unpackClient = new WebSocket(this.unpackClientURL);
+        var self = this;
         this.unpackClient.onopen = function(evt) {
             self.onWSOpen(evt, this);
         };
         this.unpackClient.onclose = function(evt) {
             self.onWSClose(evt);
+            this.unpackClient = null;
+            setTimeout(() => { self.createUnpackClient(); }, 5000);
         };
         this.unpackClient.onmessage = function(evt) {
             self.onUnpackMessage(evt);
@@ -64,6 +76,11 @@ FFW.ExternalPolicies = Em.Object.create({
         this.unpackClient.onerror = function(evt) {
             self.onWSError(evt);
         };
+    },
+
+    connect: function() {
+        this.createPackClient();
+        this.createUnpackClient();
     },
 
     onWSOpen: function(evt, socket) {


### PR DESCRIPTION
This PR is **ready** for review.

### Testing Plan
External Proprietary policy tests

### Summary
Currently, if you start the sdl_hmi in external_proprietary mode **before** connecting core and trigger a PTU, the PTU fails and the hmi log shows
```
ExternalPolicies.js:103 WebSocket is already in CLOSING or CLOSED state.
pack	@	ExternalPolicies.js:103
OnSystemRequestHandler	@	SettingsController.js:333
```

This seems to be an issue with the external policies pack and unpack client not reconnecting after the first failure

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
