### PR TITLE
Fix/Add request type param to pack and unpack requests

### DIFF
--- a/app/controller/SettingsController.js
+++ b/app/controller/SettingsController.js
@@ -308,21 +308,6 @@ SDL.SettingsController = Em.Object.create(
         ].isSDLAllowed = result;
       SDL.SettingsController.currentDeviceAllowance = null;
     },
-    OnSystemRequestHandler: function(url) {
-      if(FLAGS.ExternalPolicies === true) {
-        FFW.ExternalPolicies.pack({
-          type: 'PROPRIETARY',
-          policyUpdateFile: SDL.SettingsController.policyUpdateFile,
-          url: url
-        })
-      } else {
-        FFW.BasicCommunication.OnSystemRequest(
-          'PROPRIETARY',
-          SDL.SettingsController.policyUpdateFile,
-          url
-        );
-      }
-    },
     /**
      * Method verify what OnSystemRequest should be sent
      *
@@ -331,8 +316,8 @@ SDL.SettingsController = Em.Object.create(
     OnSystemRequestHandler: function(url) {
       if(FLAGS.ExternalPolicies === true) {
         FFW.ExternalPolicies.pack({
-          type: 'PROPRIETARY',
-          policyUpdateFile: SDL.SettingsController.policyUpdateFile,
+          requestType: 'PROPRIETARY',
+          fileName: SDL.SettingsController.policyUpdateFile,
           url: url
         })
       } else {

--- a/ffw/BasicCommunicationRPC.js
+++ b/ffw/BasicCommunicationRPC.js
@@ -570,7 +570,11 @@ FFW.BasicCommunication = FFW.RPCObserver
           }
           if (request.method == 'BasicCommunication.SystemRequest') {
             if (FLAGS.ExternalPolicies === true) {
-              FFW.ExternalPolicies.unpack(request.params.fileName);
+              FFW.ExternalPolicies.unpack({
+                requestType: request.params.requestType,
+                requestSubType: request.params.requestSubType,
+                fileName: request.params.fileName
+              });
             } else {
               this.OnReceivedPolicyUpdate(request.params.fileName);
             }

--- a/ffw/ExternalPolicies.js
+++ b/ffw/ExternalPolicies.js
@@ -92,7 +92,7 @@ FFW.ExternalPolicies = Em.Object.create({
         this.packResponseReady = true;
         FFW.BasicCommunication.OnSystemRequest(
             this.sysReqParams.type,
-            this.sysReqParams.policyUpdateFile,
+            this.sysReqParams.fileName,
             this.sysReqParams.url,
             this.sysReqParams.appID
         );
@@ -117,12 +117,11 @@ FFW.ExternalPolicies = Em.Object.create({
     pack: function(params) {
         Em.Logger.log("Pack")
         this.sysReqParams = params;
-        this.packClient.send(this.sysReqParams.policyUpdateFile);     
+        this.packClient.send(JSON.stringify(this.sysReqParams));     
     },
-    unpack: function(file) {
-        //var strJSON = JSON.stringify(obj);
+    unpack: function(params) {
         Em.Logger.log("Unpack")
-        this.unpackClient.send(file);
+        this.unpackClient.send(JSON.stringify(params));
     }
 
 });


### PR DESCRIPTION
Adds additional params to be sent in the pack/unpack requests to the policy manager script so it can decide how to handle files for different system request types.

This PR is **ready** for review.

### Summary
1. Add requestType and requestSubType params to pack/unpack requests 
2. Remove duplicate function which was added in https://github.com/smartdevicelink/sdl_hmi/commit/114f8540c67ccbfb6596c931b2a8b39b807761d0#diff-9c6a0264ae6fa261cae182013bb9ddf0R311

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
