### PR TITLE
Implement "ccpu_version" value editing

### DIFF
--- a/app/StateManager.js
+++ b/app/StateManager.js
@@ -191,6 +191,14 @@ var StateManager = Em.StateManager.extend(
                 }
               }
             ),
+            ccpuEditor: Em.State.create(
+              {
+                enter: function() {
+                  this._super();
+                  SDL.SettingsController.set('editedCcpuVersionValue', SDL.SDLModel.data.ccpuVersion);
+                }
+              }
+            ),
             deviceConfig: Em.State.create(
               {
                 enter: function() {

--- a/app/controller/SettingsController.js
+++ b/app/controller/SettingsController.js
@@ -68,6 +68,12 @@ SDL.SettingsController = Em.Object.create(
      * disallowed.
      */
     currentDeviceAllowance: null,
+
+    /**
+     * @description Value of CCPU version displayed in user input
+     */
+    editedCcpuVersionValue: "",
+
     onState: function(event) {
       SDL.States.goToStates('settings.' + event.goToState);
     },
@@ -608,6 +614,13 @@ SDL.SettingsController = Em.Object.create(
         this.model.currentSeatModel.goToStates();
         SDL.States.goToStates('settings.seat');
         }
+    },
+
+    /**
+     * @description Saves new CCPU version value from user input
+     */
+    applyNewCcpuVersionValue: function() {
+      SDL.SDLModel.data.ccpuVersion = this.editedCcpuVersionValue;
     },
 
     /**

--- a/app/model/sdl/Abstract/data.js
+++ b/app/model/sdl/Abstract/data.js
@@ -607,6 +607,11 @@ SDL.SDLModelData = Em.Object.create(
      */
     hmiUILanguage: 'EN-US',
     /**
+     * CCPU version value
+     * @type {String}
+     */
+    ccpuVersion: '12345_US',
+    /**
      * Parameter describes if performInteraction session was started on HMI
      * this flag set to true when UI.PerformInteraction request came on HMI
      * and set to false when HMI send response to SDL Core on

--- a/app/view/settings/policies/ccpuEditorView.js
+++ b/app/view/settings/policies/ccpuEditorView.js
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2020, Ford Motor Company All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met: ·
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer. · Redistributions in binary
+ * form must reproduce the above copyright notice, this list of conditions and
+ * the following disclaimer in the documentation and/or other materials provided
+ * with the distribution. · Neither the name of the Ford Motor Company nor the
+ * names of its contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+SDL.CcpuEditorView = Em.ContainerView.create(
+    {
+      elementId: 'policies_settings_ccpu_editor_view',
+      classNames: 'in_settings_separate_view',
+      classNameBindings: [
+        'SDL.States.settings.policies.ccpuEditor.active:active_state:inactive_state'
+      ],
+      childViews: [
+        'ccpuTitle',
+        'backButton',
+        'ccpuVersionLabel',
+        'ccpuVersionInput',
+        'applyButton'
+      ],
+      ccpuTitle: SDL.Label.extend(
+        {
+          classNames: 'label',
+          content: 'Configure CCPU version'
+        }
+      ),
+      backButton: SDL.Button.extend(
+        {
+          classNames: [
+            'backButton'
+          ],
+          action: 'onState',
+          target: 'SDL.SettingsController',
+          goToState: 'policies',
+          icon: 'images/media/ico_back.png',
+          onDown: false
+        }
+      ),
+      ccpuVersionLabel: SDL.Label.extend(
+        {
+          classNames: 'ccpuVersionLabel',
+          content: 'CCPU version: '
+        }
+      ),
+      ccpuVersionInput: Ember.TextField.extend(
+        {
+          elementId: 'ccpuVersionInput',
+          classNames: 'ccpuVersionInput dataInput',
+          placeholder: '<Type CCPU version here>',
+          valueBinding: 'SDL.SettingsController.editedCcpuVersionValue'
+        }
+      ),
+      applyButton: SDL.Button.extend(
+        {
+          elementId: 'applyButton',
+          classNames: 'applyButton button',
+          text: 'Apply',
+          action: 'applyNewCcpuVersionValue',
+          target: 'SDL.SettingsController',
+          onDown: false
+        }
+      )
+    }
+  );

--- a/app/view/settings/policiesView.js
+++ b/app/view/settings/policiesView.js
@@ -86,6 +86,17 @@ SDL.PoliciesView = Em.ContainerView.create(
           {
             type: SDL.Button,
             params: {
+              action: 'onState',
+              goToState: 'policies.ccpuEditor',
+              text: 'Configure CCPU version',
+              target: 'SDL.SettingsController',
+              templateName: 'arrow',
+              onDown: false,
+            }
+          },
+          {
+            type: SDL.Button,
+            params: {
               goToState: 'policies.deviceConfig',
               text: 'Allow SDL Functionality',
               action: 'onState',

--- a/app/view/settingsView.js
+++ b/app/view/settingsView.js
@@ -57,7 +57,8 @@ SDL.SettingsView = Em.ContainerView.create(
       SDL.InteriorLightView,
       SDL.ExteriorLightView,
       SDL.SeatView,
-      SDL.PolicyConfigListView
+      SDL.PolicyConfigListView,
+      SDL.CcpuEditorView
     ],
     /** Left menu */
     leftMenu: Em.ContainerView.extend(

--- a/css/settings.css
+++ b/css/settings.css
@@ -68,6 +68,29 @@
     padding-left: 10px;
 }
 
+#settingsView .in_settings_separate_view .ccpuVersionInput {
+    position: absolute;
+    left: 145px;
+    top: 115px;
+    width: 400px;
+}
+
+#settingsView .in_settings_separate_view .applyButton {
+    position: absolute;
+    left: 585px;
+    top: 115px;
+    width: 75px;
+    text-align: center;
+}
+
+#settingsView .in_settings_separate_view .label.ccpuVersionLabel {
+    position: absolute;
+    top: 110px;
+    left: 10px;
+    background: black;
+    width: 120px;
+}
+
 #settingsView .in_settings_separate_view .sendRequestButton {
     top: 210px;
     left: 130px;

--- a/ffw/BasicCommunicationRPC.js
+++ b/ffw/BasicCommunicationRPC.js
@@ -687,7 +687,7 @@ FFW.BasicCommunication = FFW.RPCObserver
                                                               // from SDL
                                                               // protocol
                 'method': request.method,
-                'ccpu_version': 'ccpu_version',
+                'ccpu_version': SDL.SDLModel.data.ccpuVersion,
                 'language': SDL.SDLModel.data.hmiUILanguage,
                 'wersCountryCode': 'wersCountryCode'
               }

--- a/ffw/UIRPC.js
+++ b/ffw/UIRPC.js
@@ -1463,6 +1463,11 @@ FFW.UI = FFW.RPCObserver.create(
                   'bitsPerSample': '8_BIT',
                   'audioType': 'PCM'
                 }],
+                "pcmStreamCapabilities": {
+                  "samplingRate"  : "16KHZ",
+                  "bitsPerSample" : "16_BIT",
+                  "audioType"	: "PCM"
+                },
                 'hmiZoneCapabilities': 'FRONT',
                 'softButtonCapabilities': [
                   {

--- a/index.html
+++ b/index.html
@@ -238,6 +238,7 @@
 <script type="text/javascript" src="app/view/settings/policiesView.js"></script>
 <script type="text/javascript" src="app/view/settings/HMISettingsView.js"></script>
 <script type="text/javascript" src="app/view/settings/policies/policyConfigDataList.js"></script>
+<script type="text/javascript" src="app/view/settings/policies/ccpuEditorView.js"></script>
 
 <script type="text/javascript" src="app/view/homeView.js"></script>
 <script type="text/javascript" src="app/view/mediaView.js"></script>


### PR DESCRIPTION
Implements [SDL-0249](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0249-Persisting-HMI-Capabilities-specific-to-headunit.md)

This PR is **ready** for review.

### Testing Plan
Will be tested manually

### Summary
Added new menu item in Settings which allows to new view for editing ccpu version.
Newly added view is displaying current CCPU version and allows to input a new value and apply it.
Once it is applied, HMI will return that new value in `GetSystemInfo` response instead of hardcoded one.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
