### PR TITLE
Fix alert maneuver

### DIFF
--- a/app/view/sdl/AlertManeuverPopUp.js
+++ b/app/view/sdl/AlertManeuverPopUp.js
@@ -151,18 +151,23 @@ SDL.AlertManeuverPopUp = Em.ContainerView.create(
       }
     },
     AlertManeuverActive: function(message) {
-      //        var self = this;
-      //
-      //        if (message.softButtons) {
-      //            this.addSoftButtons( message.softButtons );
-      //        }
-      //
-      //        this.set( 'activate', true );
-      //
-      //        clearTimeout( this.timer );
-      //        this.timer = setTimeout( function() {
-      //            self.set( 'activate', false );
-      //        }, 5000 );
+      var self = this;
+      var params = message.params;
+      if (params.softButtons) {
+          this.addSoftButtons( params.softButtons );
+      }
+
+      this.set( 'activate', true );
+
+      clearTimeout( this.timer );
+      this.timer = setTimeout( function() {
+          self.set( 'activate', false );
+          FFW.Navigation.sendNavigationResult(
+            SDL.SDLModel.data.resultCode.SUCCESS,
+            message.id,
+            message.method
+          );
+      }, 5000 );
     }
   }
 );

--- a/ffw/NavigationRPC.js
+++ b/ffw/NavigationRPC.js
@@ -293,11 +293,7 @@ FFW.Navigation = FFW.RPCObserver.create(
               return;
               //}
             }
-            this.sendNavigationResult(
-              SDL.SDLModel.data.resultCode.SUCCESS,
-              request.id,
-              request.method
-            );
+            SDL.AlertManeuverPopUp.AlertManeuverActive(request)
             break;
           }
           case 'Navigation.ShowConstantTBT':


### PR DESCRIPTION
Fixes #174 
This PR is **Ready** for review.

### Testing Plan
Send an alert maneuver with soft buttons. Verify pop up and success response.

### Summary
Re-added the alert maneuver activation function. For some reason this was commented out this whole time.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
