### PR TITLE
Fix/Remove check for non-mandatory params for choice sets

### DIFF
--- a/ffw/RPCObserver.js
+++ b/ffw/RPCObserver.js
@@ -316,9 +316,7 @@ FFW.RPCObserver = Em.Object.extend(
       if ('choiceSet' in params) {
         for (var i = params.choiceSet.length - 1; i >= 0; i--) {
           if (this.checkImage(params.choiceSet[i])) {
-            if (!('menuName' in params.choiceSet[i]) ||
-              !('secondaryText' in params.choiceSet[i]) ||
-              !('tertiaryText' in params.choiceSet[i])) {
+            if (!('menuName' in params.choiceSet[i])) {
               params.choiceSet.splice(i, 1);
             }
           }


### PR DESCRIPTION
Implements/Fixes [#265 ]

This PR is **ready** for review.

### Testing Plan
Manual testing with test_suite

### Summary

Currently, the sdl_hmi calls the `RPCObserver.checkChoice` function only when the `capabilitiesCheck` determines that there is an `UNSUPPORTED_RESOURCE`. The `checkChoice` removes a choice object if it is missing the optional `secondaryText` and `tertiaryText` parameters(as it does in the issue example). It doesn't seem to be specifically related to `STATIC` images being used in the sdl_hmi.

This PR removes the check for the optional parameters to prevent the choice object being removed from the choiceSet.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
