### PR TITLE
Fix missing request type in OnSystemRequest

### DIFF
--- a/app/controller/SettingsController.js
+++ b/app/controller/SettingsController.js
@@ -332,9 +332,10 @@ SDL.SettingsController = Em.Object.create(
      * Method responsible for PolicyUpdate retry sequence
      * abort parameter if set to true means that retry sequence if finished
      *
-     * @param {Boolean} abort
+     * @param {String} action
+     * @param {Object} request_params
      */
-    policyUpdateRetry: function(abort) {
+    policyUpdateRetry: function(action, request_params) {
       if(SDL.SDLModel.data.policyUpdateRetry.isIterationInProgress) {
         return;
       }
@@ -343,10 +344,18 @@ SDL.SettingsController = Em.Object.create(
 
       var sendOnSystemRequest = function() {
         SDL.SDLModel.data.policyUpdateRetry.isIterationInProgress = false;
+        const default_params = {
+          requestType: 'PROPRIETARY',
+          fileName: SDL.SettingsController.policyUpdateFile,
+          url: SDL.SDLModel.data.policyURLs[0]
+        };
+        const params_to_send = request_params ? request_params : default_params;
+
         FFW.BasicCommunication.OnSystemRequest(
-          'PROPRIETARY',
-          SDL.SettingsController.policyUpdateFile,
-          SDL.SDLModel.data.policyURLs[0]
+          params_to_send.requestType,
+          params_to_send.fileName,
+          params_to_send.url,
+          params_to_send.appID
         );
       }
       if(!SDL.SDLModel.data.policyUpdateRetry.isRetry) {
@@ -363,7 +372,7 @@ SDL.SettingsController = Em.Object.create(
       if(length == SDL.SDLModel.data.policyUpdateRetry.try) {
         SDL.SDLModel.data.policyUpdateRetry.isRetry = false;
       }
-      if (abort !== 'ABORT' && SDL.SDLModel.data.policyUpdateRetry.isRetry) {           
+      if (action !== 'ABORT' && SDL.SDLModel.data.policyUpdateRetry.isRetry) {           
         
         SDL.SDLModel.data.policyUpdateRetry.oldTimer = 
           SDL.SDLModel.data.policyUpdateRetry.retry[SDL.SDLModel.data.policyUpdateRetry.try] * 1000;

--- a/ffw/BasicCommunicationRPC.js
+++ b/ffw/BasicCommunicationRPC.js
@@ -287,9 +287,6 @@ FFW.BasicCommunication = FFW.RPCObserver
                             } else {
                               SDL.SettingsController.requestPTUFromEndpoint(SDL.SettingsController.policyUpdateFile, data[key].default);
                             }
-                            if (FLAGS.ExternalPolicies === true) {
-                              SDL.SettingsController.policyUpdateRetry();
-                            }
                           }
                         }
                       }
@@ -463,7 +460,7 @@ FFW.BasicCommunication = FFW.RPCObserver
               messageCode = 'StatusNeeded';
               if (FLAGS.ExternalPolicies === true && 
                   SDL.SDLModel.data.policyUpdateRetry.isRetry) {
-                SDL.SettingsController.policyUpdateRetry();
+                SDL.SettingsController.policyUpdateRetry('RETRY');
               }
               break;
             }

--- a/ffw/ExternalPolicies.js
+++ b/ffw/ExternalPolicies.js
@@ -90,15 +90,9 @@ FFW.ExternalPolicies = Em.Object.create({
     onPackMessage: function(evt) {
         Em.Logger.log('ExternalPolicies onWSMessage ' + evt.data);
         this.packResponseReady = true;
-        FFW.BasicCommunication.OnSystemRequest(
-            this.sysReqParams.type,
-            this.sysReqParams.fileName,
-            this.sysReqParams.url,
-            this.sysReqParams.appID
-        );
+        SDL.SettingsController.policyUpdateRetry('RETRY', this.sysReqParams);
 
         this.sysReqParams = {};
-
     },
     onUnpackMessage: function(evt) {
         Em.Logger.log('ExternalPolicies onWSMessage ' + evt.data);


### PR DESCRIPTION
Fixes #313 

This PR is **not ready** for review.

### Testing Plan
Will be tested manually

### Summary
There was found a few issues while working with HMI in `ExternalPolicies = true` mode:
1. HMI is sending OnSystemRequest twice
2. First OnSystremRequest notification does not contain requestType parameter (looks like a regression caused by #293)

To fix that, HMI logic was updated to launch retry sequence only after the response received by pack client. By some reason, retry sequence was additionally been started right after `GetPolicyConfigurationData` response. This extra call has been removed to make HMI send notification just once. Also, retry sequence function was updated to use request params received by pack client (if available).

### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
