### PR TITLE
Fix setting displayMode value in case of AUTO mode

### DIFF
--- a/app/model/HmiSettingsModel.js
+++ b/app/model/HmiSettingsModel.js
@@ -91,16 +91,15 @@ SDL.HmiSettingsModel = Em.Object.extend({
    * @return String (DAY or NIGHT)
    */
   defineAutoTimeValue: function() {
-    var time = new Date().toLocaleTimeString([], {hour12: false});
-    time = parseInt(time.substring(0, time.indexOf(':')));
-    return (time > 7 && time < 20? 'DAY': 'NIGHT');
+    const time = new Date().getHours();
+    return (time > 7 && time < 20 ? 'DAY': 'NIGHT');
   },
 
   setHmiSettingsData: function(data){
       var result = {};
       if(data.displayMode && this.displayMode != data.displayMode) {
         this.set('displayMode',data.displayMode);
-        result.displayMode = (data.displayMode == 'AUTO' ? this.defineAutoTimeValue() : data.displayMode);
+        result.displayMode = (data.displayMode === 'AUTO' ? this.defineAutoTimeValue() : data.displayMode);
       }
       if(data.temperatureUnit && this.temperatureUnit != data.temperatureUnit) {
         this.set('temperatureUnit',data.temperatureUnit);

--- a/app/model/HmiSettingsModel.js
+++ b/app/model/HmiSettingsModel.js
@@ -86,9 +86,7 @@ SDL.HmiSettingsModel = Em.Object.extend({
 
   defineAutoTimeValue: function() {
     var time = new Date().toLocaleTimeString([], {hour12: false});
-    console.log('TIME = ' + time);
     time = parseInt(time.substring(0, time.indexOf(':')));
-    console.log('TIME AFTER CONVERTION = ' + time.toString())
     return (time > 7 && time < 20? 'DAY': 'NIGHT');
   },
 

--- a/app/model/HmiSettingsModel.js
+++ b/app/model/HmiSettingsModel.js
@@ -84,11 +84,17 @@ SDL.HmiSettingsModel = Em.Object.extend({
     return capabilities;
   },
 
+  defineAutoTimeValue: function() {
+    var time = new Date().toLocaleTimeString();
+    time = parseInt(time.substring(0, time.indexOf(':')));
+    return (time > 7 && time < 20? 'DAY': 'NIGHT');
+  },
+
   setHmiSettingsData: function(data){
       var result = {};
       if(data.displayMode && this.displayMode != data.displayMode) {
         this.set('displayMode',data.displayMode);
-        result.displayMode = (data.displayMode == 'AUTO' ? 'DAY' : data.displayMode);
+        result.displayMode = (data.displayMode == 'AUTO' ? defineAutoTimeValue() : data.displayMode);
       }
       if(data.temperatureUnit && this.temperatureUnit != data.temperatureUnit) {
         this.set('temperatureUnit',data.temperatureUnit);
@@ -114,9 +120,7 @@ SDL.HmiSettingsModel = Em.Object.extend({
       distanceUnit: this.distanceUnit
     };
     if(result.displayMode == 'AUTO'){
-      var time = new Date().toLocaleTimeString();
-      time = parseInt(time.substring(0, time.indexOf(':')));
-      result.displayMode = (time > 7 && time < 20? 'DAY': 'NIGHT');
+      result.displayMode = defineAutoTimeValue;
     }
     return result;
   },

--- a/app/model/HmiSettingsModel.js
+++ b/app/model/HmiSettingsModel.js
@@ -85,8 +85,10 @@ SDL.HmiSettingsModel = Em.Object.extend({
   },
 
   defineAutoTimeValue: function() {
-    var time = new Date().toLocaleTimeString();
+    var time = new Date().toLocaleTimeString([], {hour12: false});
+    console.log('TIME = ' + time);
     time = parseInt(time.substring(0, time.indexOf(':')));
+    console.log('TIME AFTER CONVERTION = ' + time.toString())
     return (time > 7 && time < 20? 'DAY': 'NIGHT');
   },
 
@@ -94,7 +96,7 @@ SDL.HmiSettingsModel = Em.Object.extend({
       var result = {};
       if(data.displayMode && this.displayMode != data.displayMode) {
         this.set('displayMode',data.displayMode);
-        result.displayMode = (data.displayMode == 'AUTO' ? defineAutoTimeValue() : data.displayMode);
+        result.displayMode = (data.displayMode == 'AUTO' ? this.defineAutoTimeValue() : data.displayMode);
       }
       if(data.temperatureUnit && this.temperatureUnit != data.temperatureUnit) {
         this.set('temperatureUnit',data.temperatureUnit);
@@ -120,7 +122,7 @@ SDL.HmiSettingsModel = Em.Object.extend({
       distanceUnit: this.distanceUnit
     };
     if(result.displayMode == 'AUTO'){
-      result.displayMode = defineAutoTimeValue;
+      result.displayMode = this.defineAutoTimeValue();
     }
     return result;
   },

--- a/app/model/HmiSettingsModel.js
+++ b/app/model/HmiSettingsModel.js
@@ -84,6 +84,12 @@ SDL.HmiSettingsModel = Em.Object.extend({
     return capabilities;
   },
 
+  /**
+   * @function defineAutoTimeValue
+   * @description Defines which time value should be sent 
+   * accordingly to current system time.
+   * @return String (DAY or NIGHT)
+   */
   defineAutoTimeValue: function() {
     var time = new Date().toLocaleTimeString([], {hour12: false});
     time = parseInt(time.substring(0, time.indexOf(':')));

--- a/app/model/HmiSettingsModel.js
+++ b/app/model/HmiSettingsModel.js
@@ -88,7 +88,7 @@ SDL.HmiSettingsModel = Em.Object.extend({
       var result = {};
       if(data.displayMode && this.displayMode != data.displayMode) {
         this.set('displayMode',data.displayMode);
-        result.displayMode = data.displayMode;
+        result.displayMode = (data.displayMode == 'AUTO' ? 'DAY' : data.displayMode);
       }
       if(data.temperatureUnit && this.temperatureUnit != data.temperatureUnit) {
         this.set('temperatureUnit',data.temperatureUnit);


### PR DESCRIPTION
Implements/Fixes [#310](https://github.com/smartdevicelink/sdl_hmi/issues/310)

This PR is **ready** for review.

### Testing Plan
Manual testing

### Summary
In case of hmi settings update there was no condition for `displayMode=AUTO` coming.
Added next condition - if `displayMode=AUTO` comes from SDL then response message should contain `displayMode=DAY`, otherwise return as is. 

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
