### PR TITLE
Fix issues with PROPRIETARY/HTTP update flow

### DIFF
--- a/app/controller/SettingsController.js
+++ b/app/controller/SettingsController.js
@@ -535,12 +535,10 @@ SDL.SettingsController = Em.Object.create(
 
         FLAGS.set('PTUWithModemEnabled', false); // switch back to PTU via mobile
 
-        if (urls.length > 0) {
-          urls.forEach(url => {
-            SDL.SettingsController.OnSystemRequestHandler(url);
-          });
+        if (urls.length > 0 && FLAGS.ExternalPolicies === true) {
+          SDL.SettingsController.OnSystemRequestHandler(urls[0]);
         } else {
-          FFW.BasicCommunication.OnSystemRequest('PROPRIETARY');
+          SDL.SettingsController.OnSystemRequestHandler();
         }
       };
 

--- a/ffw/BasicCommunicationRPC.js
+++ b/ffw/BasicCommunicationRPC.js
@@ -712,6 +712,13 @@ FFW.BasicCommunication = FFW.RPCObserver
                 nestedProperty: 7 //Service type for policies
               });
             }
+            else if (FLAGS.PTUWithModemEnabled) {
+              this.GetPolicyConfigurationData({
+                policyType: 'module_config',
+                property: 'endpoints',
+                nestedProperty: 7 //Service type for policies
+              });
+            }
             else {
               SDL.SettingsController.OnSystemRequestHandler();
             }

--- a/ffw/BasicCommunicationRPC.js
+++ b/ffw/BasicCommunicationRPC.js
@@ -278,11 +278,9 @@ FFW.BasicCommunication = FFW.RPCObserver
                             SDL.SDLModel.data.set('policyURLs', data[key].default);
                             if(!FLAGS.PTUWithModemEnabled) {
                               if (data[key].default.length) {
-                                data[key].default.forEach(url => {
-                                  SDL.SettingsController.OnSystemRequestHandler(url);
-                                })
+                                SDL.SettingsController.OnSystemRequestHandler(data[key].default[0]);
                               } else {
-                                this.OnSystemRequest('PROPRIETARY');
+                                SDL.SettingsController.OnSystemRequestHandler();
                               }
                             } else {
                               SDL.SettingsController.requestPTUFromEndpoint(SDL.SettingsController.policyUpdateFile, data[key].default);
@@ -703,15 +701,20 @@ FFW.BasicCommunication = FFW.RPCObserver
           }
           if (request.method == 'BasicCommunication.PolicyUpdate') {
             SDL.SettingsController.policyUpdateFile = request.params.file;
-            SDL.SDLModel.data.policyUpdateRetry.timeout
-              = request.params.timeout;
-            SDL.SDLModel.data.policyUpdateRetry.retry = request.params.retry;
-            SDL.SDLModel.data.policyUpdateRetry.try = 0;
-            this.GetPolicyConfigurationData({
-              policyType: 'module_config',
-              property: 'endpoints',
-              nestedProperty: 7 //Service type for policies
-            }); 
+            if (FLAGS.ExternalPolicies === true) {
+              SDL.SDLModel.data.policyUpdateRetry.timeout
+                = request.params.timeout;
+              SDL.SDLModel.data.policyUpdateRetry.retry = request.params.retry;
+              SDL.SDLModel.data.policyUpdateRetry.try = 0;
+              this.GetPolicyConfigurationData({
+                policyType: 'module_config',
+                property: 'endpoints',
+                nestedProperty: 7 //Service type for policies
+              });
+            }
+            else {
+              SDL.SettingsController.OnSystemRequestHandler();
+            }
             this.sendBCResult(
               SDL.SDLModel.data.resultCode.SUCCESS, request.id, request.method
             );
@@ -1434,9 +1437,7 @@ FFW.BasicCommunication = FFW.RPCObserver
           'params': {
             'requestType': type,
             'fileType': 'JSON',
-            'offset': 1000,
-            'length': 10000,
-            'timeout': 500,
+            'timeout': 1000,
             'fileName': fileName
           }
         };


### PR DESCRIPTION

See also: https://github.com/smartdevicelink/sdl_core/pull/3329

This PR is **ready** for review.

### Testing Plan
Check logs and verify that OnSystemRequest is sent without a `url` if not using External Policies, also verify that SDL.GetPolicyConfigurationData is not sent in this case

### Summary
Skip GetPolicyConfigurationData step for PROPRIETARY/HTTP mode and send OnSystemRequest without URL immediately after BC.PolicyUpdate. Also fixes issue where several OnSystemRequests were sent at the same time if multiple `default` URLs were provided.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
