### PR TITLE
Fix preset name for OK button

### DIFF
--- a/app/view/home/controlButtons.js
+++ b/app/view/home/controlButtons.js
@@ -625,14 +625,12 @@ getCurrentDisplayModeClass: function() {
                 elementId: 'OK',
                 classNames: 'OkBtn',
                 time: 0,
-                presetName: 'OK',
+                presetName: 'PLAY_PAUSE',
                 actionDown: function() {
-
                   this._super();
                   SDL.SDLController.onSoftButtonOkActionDown(this.presetName);
                 },
                 actionUp: function() {
-
                   this._super();
                   SDL.SDLController.onSoftButtonOkActionUp(this.presetName);
                 }


### PR DESCRIPTION
Fixes #301 

This PR is **not ready** for review.

### Testing Plan
Covered by manual testing

### Summary
Starting from release 5.0 HMI should use `PLAY_PAUSE` preset name instead of `OK`.

### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
