### PR TITLE
Restore alert icon visibility after error

### DIFF
--- a/app/view/sdl/AlertPopUp.js
+++ b/app/view/sdl/AlertPopUp.js
@@ -70,10 +70,14 @@ SDL.AlertPopUp = Em.ContainerView.create(
       {
         elementId: 'alertPopUpImage',
         template: Ember.Handlebars.compile(
-          '<img class="alertPopUpImage" onerror="SDL.AlertPopUp.imageUndefined(event)" {{bindAttr src="SDL.AlertPopUp.icon"}}>'
+          '<img class="alertPopUpImage" \
+            onerror="SDL.AlertPopUp.imageUndefined(event)"\
+            onload="SDL.AlertPopUp.imageLoaded(event)"\
+            {{bindAttr src="SDL.AlertPopUp.icon"}}>'
         )
       }
     ),
+
     /**
      * @function imageUndefined
      * @param {Object} event
@@ -84,6 +88,16 @@ SDL.AlertPopUp = Em.ContainerView.create(
       this.message = "Requested image(s) not found";
       this.reason = "WARNINGS"
     },
+
+    /**
+     * @function imageLoaded
+     * @param {Object} event
+     * @description action if an image loaded.
+     */
+    imageLoaded: function(event) {
+      event.target.style.display='block';
+    },
+
     /**
      * Wagning image on Alert PopUp
      */


### PR DESCRIPTION
Fixes #307 

This PR is **not ready** for review.

### Testing Plan
Covered by manual testing

### Summary
Restore alert icon style after error has happened. Was added `onload` callback which restores alert icon visibility if it was invisible on previous Alert request.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
