### PR TITLE
Fix handling RPC from unknown interface

### DIFF
--- a/ffw/RPCClient.js
+++ b/ffw/RPCClient.js
@@ -143,11 +143,16 @@ FFW.RPCClient = Em.Object.create(
        if(observerName === "SDL"){
         observerName = "BasicCommunication";
        }
+      }
 
+      if (observerName in this.observerMap) {
        // Verification of unsupported params and remove them from original
        // request Changing filenames with backslash - escape the \ with %5C
        // due to Issue 45051 in chromium
        this.observerMap[observerName].checkImage(jsonObj.params);
+      } else if (observerName != "") {
+        Em.Logger.log(`RPCClient: No observer found for interface "${observerName}"`);
+        return;
       }
 
       // Verification of unsupported params and remove them from original


### PR DESCRIPTION
Fixes #308 

This PR is **ready** for review.

### Testing Plan
Covered by manual testing

### Summary
Fix `typeError` exceptions thrown by HMI on receiving RPCs from unsupported/unknown interface

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
