### PR TITLE
Fix setting `channelSetting` with SetInteriorVehicleData

### DIFF
--- a/app/model/media/AudioModel.js
+++ b/app/model/media/AudioModel.js
@@ -888,12 +888,12 @@ SDL.AudioModel = Em.Object.extend({
           resultNew.volume = data.volume;
         }
         for (var i = 0; i < dataLength; i++) {
+          if (data.equalizerSettings[i].channelId == this.tempEqualizerSettings.channelId) {
+            this.set('tempEqualizerSettings.channelSetting', data.equalizerSettings[i].channelSetting);
+          }
           for (var j = 0; j < currentLength; j++) {
             if (data.equalizerSettings[i].channelId == this.lastRadioControlStruct.equalizerSettings[j].channelId) {
               this.lastRadioControlStruct.equalizerSettings[j].channelSetting = SDL.deepCopy(data.equalizerSettings[i].channelSetting);
-              if (j == this.tempEqualizerSettIndex - 1) {
-                this.set('tempEqualizerSettings.equalizerSettings', data.equalizerSettings[i].equalizerSettings);
-              }
             }
           }
         }

--- a/app/model/media/AudioModel.js
+++ b/app/model/media/AudioModel.js
@@ -832,12 +832,12 @@ SDL.AudioModel = Em.Object.extend({
           resultNew.volume = data.volume;
         }
         for (var i = 0; i < dataLength; i++) {
+          if (data.equalizerSettings[i].channelId == this.tempEqualizerSettings.channelId) {
+            this.set('tempEqualizerSettings.channelSetting', data.equalizerSettings[i].channelSetting);
+          }
           for (var j = 0; j < currentLength; j++) {
             if (data.equalizerSettings[i].channelId == this.lastRadioControlStruct.equalizerSettings[j].channelId) {
               this.lastRadioControlStruct.equalizerSettings[j].channelSetting = SDL.deepCopy(data.equalizerSettings[i].channelSetting);
-              if (j == this.tempEqualizerSettIndex - 1) {
-                this.set('tempEqualizerSettings.equalizerSettings', data.equalizerSettings[i].equalizerSettings);
-              }
             }
           }
         }

--- a/app/model/media/AudioModel.js
+++ b/app/model/media/AudioModel.js
@@ -838,6 +838,7 @@ SDL.AudioModel = Em.Object.extend({
           for (var j = 0; j < currentLength; j++) {
             if (data.equalizerSettings[i].channelId == this.lastRadioControlStruct.equalizerSettings[j].channelId) {
               this.lastRadioControlStruct.equalizerSettings[j].channelSetting = SDL.deepCopy(data.equalizerSettings[i].channelSetting);
+              break;
             }
           }
         }
@@ -894,6 +895,7 @@ SDL.AudioModel = Em.Object.extend({
           for (var j = 0; j < currentLength; j++) {
             if (data.equalizerSettings[i].channelId == this.lastRadioControlStruct.equalizerSettings[j].channelId) {
               this.lastRadioControlStruct.equalizerSettings[j].channelSetting = SDL.deepCopy(data.equalizerSettings[i].channelSetting);
+              break;
             }
           }
         }


### PR DESCRIPTION
Implements/Fixes #309 

This PR is **ready** for review.

### Testing Plan
Manual testing

### Summary
In case of incoming update for equalizer data there was not correct update for temporary data on audio popup window.
So in this PR update of temporary values for audio popup window was reworked.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
