### PR TITLE
Fix OnInteriorVehicleData with incorrect type on press XM radio preset button

### DIFF
--- a/app/model/media/AudioModels/RadioModel.js
+++ b/app/model/media/AudioModels/RadioModel.js
@@ -1192,19 +1192,18 @@ SDL.RadioModel = Em.Object.extend({
         this.setFrequencyInteger(parseInt(data));
       }
       if (this.radioControlStruct.band === 'XM') {
-        this.setFrequencyInteger(parseInt(
-          (function(value){
+        var getBand = function(value, stations){
             var kArray = [], vArray = [];
-            for (key in this.xmStations) {
+            for (key in stations) {
               kArray.push(key);
-              vArray.push(this.xmStations[key]);
+              vArray.push(stations[key]);
             }
 
             var vIndex = vArray.indexOf(value);
 
             return kArray[vIndex];
-          })(data)
-        ));
+        };
+        this.setFrequencyInteger(parseInt(getBand(data,this.xmStations)));
       }
 
       this.updateCurrentFrequencyInfo();


### PR DESCRIPTION
Fixes #312

This PR is **[not ready]** for review.

### Testing Plan
Covered by manual testing

### Summary
In case of pressing on XM radio preset button the incorrect value of  frequency Integer of `OnInteriorVehicleData` was returned. Was fixed creation of `OnInteriorVehicleData` value in case Xm radio.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
