### PR TITLE
Fix soft button image in AlertManeuer and Alert popups

### DIFF
--- a/app/view/sdl/AlertManeuverPopUp.js
+++ b/app/view/sdl/AlertManeuverPopUp.js
@@ -133,15 +133,25 @@ SDL.AlertManeuverPopUp = Em.ContainerView.create(
             break;
         }
         for (var i = 0; i < params.length; i++) {
+          let get_template_type = function(button_type) {
+            switch (params[i].type) {
+              case "IMAGE":
+                return "icon";
+              case "BOTH":
+                return "rightText";
+            }
+            return "text";
+          }
+
           this.get('softbuttons.childViews').pushObject(
             SDL.Button.create(
               SDL.PresetEventsCustom, {
                 softButtonID: params[i].softButtonID,
-                icon: params[i].image,
+                icon: params[i].image ? params[i].image.value : '',
                 text: params[i].text,
                 classNames: 'list-item softButton ' + softButtonsClass,
                 elementId: 'softButton' + i,
-                templateName: params[i].image ? 'rightIcon' : 'text',
+                templateName: get_template_type(params[i].type),
                 systemAction: params[i].systemAction,
                 appID: params.appID
               }

--- a/css/sdl.css
+++ b/css/sdl.css
@@ -99,7 +99,7 @@
 }
 
 .softButton .right_text {
-    padding-left: 5px !important;
+    padding-left: 50px;
 }
 
 .sdl-window .back-button {
@@ -1455,8 +1455,8 @@
 #baseNavigation .softButton, #AlertManeuverPopUp .softButton, #AudioPassThruPopUp .softButton, #AlertPopUp .softButton {
     border: 1px solid #393939;
     border-radius: 3px;
-    height: 42px;
-    line-height: 42px;
+    height: 50px;
+    line-height: 45px;
     text-align: center;
     float: left;
     margin: 10px;


### PR DESCRIPTION
Fixes #324 and #327 

This PR is **ready** for review.

### Testing Plan
Covered by manual testing

### Summary
There was a wrong style specified for a right text button template causing text overlapping with icon. Also, HMI should consider three different template options depending on soft button type. Also, icon assignment was wrong.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
