### PR TITLE
properly handle response from shaid appstore

### DIFF
--- a/app/controller/InfoController.js
+++ b/app/controller/InfoController.js
@@ -367,7 +367,12 @@ SDL.InfoController = Em.Object.create(
      * @param {String} response string containing server response
      */
     processAppsStoreResponse: function(response) {
-      var json_content = response;
+      var json_content = [];
+      if (response.data && response.data.applications) {
+        json_content = response.data.applications
+      } else {
+        json_content = response
+      }
 
       if (!Array.isArray(json_content)) {
         Em.Logger.log('Wrong data format!');


### PR DESCRIPTION
This PR is **ready** for review.

### Testing Plan
Manual testing

### Summary
SDL Servers app store response contains a different structure than the plain json object returned by our S3 app list example. This PR give the HMI the ability to understand either type of response.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
