### PR TITLE
Fix margin for icons in POI list

### DIFF
--- a/css/general.css
+++ b/css/general.css
@@ -1120,7 +1120,7 @@ margin-top: 90px;
 
 .list-item span {
     position: relative;
-    margin-left: 5px;
+    margin-left: 55px;
     float: left;
 }
 


### PR DESCRIPTION
Implements/Fixes #328 

This PR is **ready** for review.

### Testing Plan
Manual testing

### Summary
Text of location names in POI list had too small margin, 
that didn't count on POI images. So text margin was increased.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
