### PR TITLE
Fix SUCCESS resultCode is returned for request with softButtons

### DIFF
--- a/app/model/sdl/MediaModel.js
+++ b/app/model/sdl/MediaModel.js
@@ -335,6 +335,25 @@ SDL.SDLMediaModel = SDL.ABSAppModel.extend({
     if(this.getWidgetModel(params.windowID)) {
       this.widgetShow(params);
     }
+
+   var is_png_image = function(file_name) {
+      var search_offset = file_name.lastIndexOf('.');
+      return file_name.includes('.png', search_offset);
+    };
+
+    if (params.softButtons) {
+      for (var i=0; i < params.softButtons.length; ++i) {
+       var button = params.softButtons[i];
+       if (!button.image) {
+         continue;
+        }
+        var button_image = button.image;
+        if (!is_png_image(button_image.value) && button_image.isTemplate) {
+        return SDL.SDLModel.data.resultCode.WARNINGS;
+        }
+      }
+    }
+    return SDL.SDLModel.data.resultCode.SUCCESS;
   },
 
   mainWindowShow: function(params) {

--- a/app/model/sdl/NonMediaModel.js
+++ b/app/model/sdl/NonMediaModel.js
@@ -174,6 +174,25 @@ SDL.SDLNonMediaModel = SDL.ABSAppModel.extend({
     if(this.getWidgetModel(params.windowID)) {
       this.widgetShow(params);
     }
+
+    var is_png_image = function(file_name) {
+      var search_offset = file_name.lastIndexOf('.');
+      return file_name.includes('.png', search_offset);
+    };
+
+    if (params.softButtons) {
+      for (var i=0; i < params.softButtons.length; ++i) {
+       var button = params.softButtons[i];
+       if (!button.image) {
+         continue;
+        }
+        var button_image = button.image;
+        if (!is_png_image(button_image.value) && button_image.isTemplate) {
+        return SDL.SDLModel.data.resultCode.WARNINGS;
+        }
+      }
+    }
+    return SDL.SDLModel.data.resultCode.SUCCESS;
   },
 
   /**

--- a/app/view/sdl/AlertManeuverPopUp.js
+++ b/app/view/sdl/AlertManeuverPopUp.js
@@ -51,6 +51,7 @@ SDL.AlertManeuverPopUp = Em.ContainerView.create(
     content1: 'Title',
     content2: 'Text',
     activate: false,
+    areImagesValid: true,
     timer: null,
     /**
      * Wagning image on Alert Maneuver PopUp
@@ -132,6 +133,12 @@ SDL.AlertManeuverPopUp = Em.ContainerView.create(
             softButtonsClass = 'four';
             break;
         }
+
+        var is_png_image = function(file_name) {
+          var search_offset = file_name.lastIndexOf('.');
+          return file_name.includes('.png', search_offset);
+        }
+
         for (var i = 0; i < params.length; i++) {
           this.get('softbuttons.childViews').pushObject(
             SDL.Button.create(
@@ -147,12 +154,19 @@ SDL.AlertManeuverPopUp = Em.ContainerView.create(
               }
             )
           );
+          if (params[i].image==null){
+            continue;
+          }
+          if (!is_png_image(params[i].image.value) && params[i].image.isTemplate) {
+              this.set('areImagesValid',false);
+            }
         }
       }
     },
     AlertManeuverActive: function(message) {
       var self = this;
       var params = message.params;
+      this.set('areImagesValid',true);
       if (params.softButtons) {
           this.addSoftButtons( params.softButtons );
       }
@@ -160,10 +174,12 @@ SDL.AlertManeuverPopUp = Em.ContainerView.create(
       this.set( 'activate', true );
 
       clearTimeout( this.timer );
+      var self = this;
       this.timer = setTimeout( function() {
           self.set( 'activate', false );
+          var resultCode = self.areImagesValid?SDL.SDLModel.data.resultCode.SUCCESS : SDL.SDLModel.data.resultCode.WARNINGS;
           FFW.Navigation.sendNavigationResult(
-            SDL.SDLModel.data.resultCode.SUCCESS,
+            resultCode,
             message.id,
             message.method
           );

--- a/app/view/sdl/AlertPopUp.js
+++ b/app/view/sdl/AlertPopUp.js
@@ -193,6 +193,12 @@ SDL.AlertPopUp = Em.ContainerView.create(
             softButtonsClass = 'four';
             break;
         }
+
+        var is_png_image = function(file_name) {
+          var search_offset = file_name.lastIndexOf('.');
+          return file_name.includes('.png', search_offset);
+        }
+        
         for (var i = 0; i < params.length; i++) {
           this.get('softbuttons.buttons.childViews')
             .pushObject(
@@ -217,6 +223,10 @@ SDL.AlertPopUp = Em.ContainerView.create(
                 }
               )
             );
+
+          if (!is_png_image(params[i].image.value) && params[i].image.isTemplate) {
+               this.reason = "WARNINGS";
+          }
         }
       }
     },

--- a/app/view/sdl/shared/scrollableMessage.js
+++ b/app/view/sdl/shared/scrollableMessage.js
@@ -48,6 +48,7 @@ SDL.ScrollableMessage = SDL.SDLAbstractView.create(
     active: false,
     appID: null,
     timer: null,
+    areImagesValid: true,
     timeout: null,
     childViews: [
       'backButton', 'captionText', 'softButtons', 'listOfCommands'
@@ -63,9 +64,13 @@ SDL.ScrollableMessage = SDL.SDLAbstractView.create(
       this.set('active', false);
       this.softButtons.set('page', 0);
       this.timeout = null;
+      var resultCode = this.areImagesValid?SDL.SDLModel.data.resultCode.SUCCESS : SDL.SDLModel.data.resultCode.WARNINGS;
+      if(ABORTED) {
+        resultCode =SDL.SDLModel.data.resultCode.ABORTED;
+      }
+
       SDL.SDLController.scrollableMessageResponse(
-        ABORTED ? SDL.SDLModel.data.resultCode['ABORTED'] :
-          SDL.SDLModel.data.resultCode.SUCCESS, this.messageRequestId
+        resultCode, this.messageRequestId
       );
       SDL.SDLController.onSystemContextChange();
       SDL.SDLModel.data.registeredApps.forEach(app => {
@@ -82,6 +87,26 @@ SDL.ScrollableMessage = SDL.SDLAbstractView.create(
         }
         this.set('messageRequestId', messageRequestId);
         this.set('captionText.content', appName);
+
+        var is_png_image = function(file_name) {
+          var search_offset = file_name.lastIndexOf('.');
+          return file_name.includes('.png', search_offset);
+        }
+        
+         this.set('areImagesValid',true);
+
+        for (var i=0; i < params.softButtons.length; ++i) {
+          var button = params.softButtons[i];
+          if (!button.image) {
+           continue;
+          }
+          var button_image = button.image;
+
+          if (!is_png_image(button_image.value) && button_image.isTemplate) {
+            this.set('areImagesValid',false);
+          }
+        }
+    
         this.softButtons.addItems(params.softButtons, params.appID);
         this.set('active', true);
         this.set('cancelID', params.cancelID);

--- a/ffw/UIRPC.js
+++ b/ffw/UIRPC.js
@@ -237,16 +237,16 @@ FFW.UI = FFW.RPCObserver.create(
                 request.params.templateConfiguration.nightColorScheme)) {
                   sendCapabilityUpdated = true;
               }
-          }
-            if(appModel.onSDLUIShow(request.params) === SDL.SDLModel.data.resultCode.REJECTED) {
+            }
+
+            var ui_show_result = appModel.onSDLUIShow(request.params);
+            if(ui_show_result === SDL.SDLModel.data.resultCode.REJECTED) {
               this.sendError(SDL.SDLModel.data.resultCode.REJECTED, request.id, request.method,
                     "Widget is duplicating other window. Rejecting UI.Show request.");
               return;
             }
             SDL.InfoAppsView.showAppList();
-            this.sendUIResult(
-              SDL.SDLModel.data.resultCode.SUCCESS, request.id, request.method
-            );
+            this.sendUIResult(ui_show_result, request.id, request.method);
             if (sendCapabilityUpdated) {
               let capability = SDL.SDLController.getDefaultCapabilities(request.params.windowID, request.params.appID);
               FFW.BasicCommunication.OnSystemCapabilityUpdated(capability);


### PR DESCRIPTION
Fixes [#321 ](https://github.com/smartdevicelink/sdl_hmi/issues/321)

This PR is **not ready** for review.
**Notice this PR should be merged only after** [smartdevicelink/sdl_hmi #344](https://github.com/smartdevicelink/sdl_hmi/pull/344)

### Testing Plan
Covered by manual testing plan

### Summary
Is returned SUCCESS resultCode  from HMI for request with softButtons with .jpeg image and isTemplate=true, instead of WARNINGS resultCode. Added checks of .png image type in softButtons.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
