### PR TITLE
Fix adding new location data into POI list

### DIFF
--- a/app/controller/NavigationController.js
+++ b/app/controller/NavigationController.js
@@ -49,7 +49,7 @@ SDL.NavigationController = Em.Object.create(
      * @param {Object} request
      */
     sendLocation: function(request) {
-      this.model.LocationDetails.push(
+      this.model.LocationDetails.pushObject(
         {
           coordinate: {
             latitudeDegrees: request.params.latitudeDegrees,


### PR DESCRIPTION
Implements/Fixes #325 

This PR is **ready** for review.

### Testing Plan
Manual testing

### Summary
In case of appending POI list with new location data there was no update of POI list. 
The reason for such behavior - new location data appended into `SDL.NavigationModel.LocationDetails` array directly instead of using Ember object notification system. 
So now, location data appends through Ember object notification system.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
