### PR TITLE
Fix/policy table update status button

### DIFF
--- a/ffw/BasicCommunicationRPC.js
+++ b/ffw/BasicCommunicationRPC.js
@@ -365,7 +365,9 @@ FFW.BasicCommunication = FFW.RPCObserver
         }
         if (response.result.method == 'SDL.GetStatusUpdate') {
           Em.Logger.log('SDL.GetStatusUpdate: Response from SDL!');
-          SDL.PopUp.create().appendTo('body').popupActivate(response.result);
+          SDL.PopUp.create().appendTo('body').popupActivate(
+            "Update Status: " + response.result.status, null, false 
+          );
         }
         if (response.result.method == 'BasicCommunication.GetAppProperties') {
           Em.Logger.log('BasicCommunication.GetAppProperties: Response from SDL!');


### PR DESCRIPTION
This PR is **ready** for review.

### Summary
Currently trying to use the `Policy table update status` button in the settings results in an empty popup and this error message in the logs

>Uncaught TypeError: textBody.split is not a function
    at d.popupActivate (PopUp.js:151)
    at d.onRPCResult (BasicCommunicationRPC.js:368)
    at d [as onRPCResult] (ember-1.0.pre.min.js:14)
    at d.onWSMessage (RPCClient.js:185)
    at WebSocket.socket.onmessage (RPCClient.js:81)

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
