### PR TITLE
Fix warnings on static image for PerformInteraction RPC

### DIFF
--- a/ffw/UIRPC.js
+++ b/ffw/UIRPC.js
@@ -325,21 +325,18 @@ FFW.UI = FFW.RPCObserver.create(
           {
 
             // Verify if there is an unsupported data in request
-            //if (this.errorResponsePull[request.id] != null) {
-            //
-            ////Check if there is any available data to  process the request
-            //if ("choiceSet" in request.params
-            //    && request.params
-            //    && request.params.interactionLayout != "KEYBOARD") {
-            //
-            //    this.errorResponsePull[request.id].code =
-            // SDL.SDLModel.data.resultCode["WARNINGS"]; } else { If no
-            // available data sent error response and stop process current
-            // request this.sendError(this.errorResponsePull[request.id].code,
-            // request.id, request.method, "Unsupported " +
-            // this.errorResponsePull[request.id].type + " type. Request was
-            // not processed."); this.errorResponsePull[request.id] = null;
-            // return; } }
+            if (this.errorResponsePull[request.id] != null) {
+              if (request.params && 'choiceSet' in request.params && request.params.interactionLayout != "KEYBOARD") {
+                if (this.errorResponsePull[request.id].type === 'STATIC') {
+                  this.sendError(SDL.SDLModel.data.resultCode['UNSUPPORTED_RESOURCE'], 
+                                request.id, 
+                                request.method, 
+                                'Image of STATIC type is not supported on HMI. Request was not processed');
+                  return;
+                }
+              }
+            }
+
             if (SDL.SDLModel.uiPerformInteraction(request)) {
               SDL.SDLController.onSystemContextChange();
               SDL.SDLModel.data.registeredApps.forEach(app => {


### PR DESCRIPTION
Implements/Fixes [#330](https://github.com/smartdevicelink/sdl_hmi/issues/330)

This PR is **ready** for review.

### Testing Plan
Manual testing

### Summary
Added error response with UNSUPPORTED_RESOURCE for PerformInteraction RPC 
in case of STATIC image type present in request.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
