### PR TITLE
External OnSystemRequest retry fixes

### DIFF
--- a/app/controller/SettingsController.js
+++ b/app/controller/SettingsController.js
@@ -351,12 +351,6 @@ SDL.SettingsController = Em.Object.create(
       }
       if(abort !== 'ABORT' && !SDL.SDLModel.data.policyUpdateRetry.isRetry) {
         SDL.SDLModel.data.policyUpdateRetry.isRetry = true;
-        SDL.SDLModel.data.policyUpdateRetry.isIterationInProgress = true;
-        SDL.SDLModel.data.policyUpdateRetry.timer = setTimeout(
-          function() {
-            sendOnSystemRequest();
-          }, 1000
-        );
         return;
       }
       var length = SDL.SDLModel.data.policyUpdateRetry.retry.length;
@@ -537,6 +531,7 @@ SDL.SettingsController = Em.Object.create(
 
         if (urls.length > 0 && FLAGS.ExternalPolicies === true) {
           SDL.SettingsController.OnSystemRequestHandler(urls[0]);
+          SDL.SettingsController.policyUpdateRetry();
         } else {
           SDL.SettingsController.OnSystemRequestHandler();
         }

--- a/app/controller/SettingsController.js
+++ b/app/controller/SettingsController.js
@@ -349,7 +349,7 @@ SDL.SettingsController = Em.Object.create(
           SDL.SDLModel.data.policyURLs[0]
         );
       }
-      if(!SDL.SDLModel.data.policyUpdateRetry.isRetry) {
+      if(abort !== 'ABORT' && !SDL.SDLModel.data.policyUpdateRetry.isRetry) {
         SDL.SDLModel.data.policyUpdateRetry.isRetry = true;
         SDL.SDLModel.data.policyUpdateRetry.isIterationInProgress = true;
         SDL.SDLModel.data.policyUpdateRetry.timer = setTimeout(

--- a/ffw/BasicCommunicationRPC.js
+++ b/ffw/BasicCommunicationRPC.js
@@ -282,11 +282,11 @@ FFW.BasicCommunication = FFW.RPCObserver
                               } else {
                                 SDL.SettingsController.OnSystemRequestHandler();
                               }
+                              if (FLAGS.ExternalPolicies === true) {
+                                SDL.SettingsController.policyUpdateRetry();
+                              }
                             } else {
                               SDL.SettingsController.requestPTUFromEndpoint(SDL.SettingsController.policyUpdateFile, data[key].default);
-                            }
-                            if (FLAGS.ExternalPolicies === true) {
-                              SDL.SettingsController.policyUpdateRetry();
                             }
                           }
                         }

--- a/ffw/ExternalPolicies.js
+++ b/ffw/ExternalPolicies.js
@@ -91,7 +91,7 @@ FFW.ExternalPolicies = Em.Object.create({
         Em.Logger.log('ExternalPolicies onWSMessage ' + evt.data);
         this.packResponseReady = true;
         FFW.BasicCommunication.OnSystemRequest(
-            this.sysReqParams.type,
+            this.sysReqParams.requestType,
             this.sysReqParams.fileName,
             this.sysReqParams.url,
             this.sysReqParams.appID


### PR DESCRIPTION
Implements/Fixes #365 

This PR is **ready** for review.

### Testing Plan
HMI PTU mobile retry sequence as described in issue.

### Summary
Adds some fixes to onSystemRequest related sequences.

- Fixes param name for external policies pack message. Before this there was no requestType included in the onSystemRequest.
- Fixes retry sequence where ABORT was starting another OnSystemRequest timer that was being sent.
- Moved retry update call to non-hmi ptu sequence to prevent extra OSR messages to be sent to core since the HMI ptu feature has its own retry logic.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
