### PR TITLE
Fix error when display mode changed for non-media app

### DIFF
--- a/app/model/sdl/NonMediaModel.js
+++ b/app/model/sdl/NonMediaModel.js
@@ -273,6 +273,29 @@ SDL.SDLNonMediaModel = SDL.ABSAppModel.extend({
   sdlSetMediaClockTimer: function() {
 
     return;
-  }
+  },
+
+  classNameBindings: [
+    'dayMode',
+    'nightMode',
+    'highLightedMode'
+  ],
+
+  dayMode:false,
+  nightMode:false,
+  highLightedMode:false,
+
+    /**
+     * @description Method applies image mode view for model.
+     * @param {Number}
+     */
+  setMode:function(mode){
+    if(this.isTemplate){
+      mode = SDL.SDLModel.data.imageModeList.includes(mode) ? mode : SDL.SDLModel.data.imageModeList[0];
+      this.set('dayMode', mode == SDL.SDLModel.data.imageModeList[0]);
+      this.set('nightMode', mode == SDL.SDLModel.data.imageModeList[1]);
+      this.set('highLightedMode', mode == SDL.SDLModel.data.imageModeList[2]);
+    }
+  },
 }
 );


### PR DESCRIPTION
Implements/Fixes [#351](https://github.com/smartdevicelink/sdl_hmi/issues/351)

This PR is **ready** for review.

### Testing Plan
Manual testing

### Summary
There was no `setMode` method defined for NonMediaModel. This caused exception described in https://github.com/smartdevicelink/sdl_hmi/issues/351.
So appropriate method was added.

### CLA
- [X] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
