### PR TITLE
Implement additional submenus and driver distraction limits

### DIFF
--- a/app/controller/sdl/Abstract/Controller.js
+++ b/app/controller/sdl/Abstract/Controller.js
@@ -220,10 +220,10 @@ SDL.SDLController = Em.Object.extend(
      * StateManager
      */
     deactivateApp: function() {
+      SDL.SDLController.onSubMenu('top');
       if (this.model) {
         SDL.SDLModel.onDeactivateApp(SDL.States.nextState, this.model.appID);
       }
-      SDL.SDLController.onSubMenu('top');
       SDL.SDLController.model.set('tbtActivate', false);
       this.set('model', null);
     },

--- a/app/controller/sdl/Abstract/Controller.js
+++ b/app/controller/sdl/Abstract/Controller.js
@@ -135,7 +135,12 @@ SDL.SDLController = Em.Object.extend(
      * @param id {Number}
      */
     onSubMenu: function(id) {
-      this.model.set('currentSubMenuId', id);
+      if (id >= 0 && id != 'top') {
+        this.model.set('currentMenuDepth', this.model.currentMenuDepth + 1);
+      } else {
+        this.model.set('currentMenuDepth', 0);
+      }      
+      this.model.set('currentSubMenuId', id);      
     },
     /**
      * Comparison function for sort array of buttons in options list by

--- a/app/controller/sdl/Abstract/Controller.js
+++ b/app/controller/sdl/Abstract/Controller.js
@@ -110,6 +110,7 @@ SDL.SDLController = Em.Object.extend(
         }
       } else {
         FFW.UI.onCommand(element.commandID, this.model.appID);
+        this.model.set('currentSubMenuId', 'top');
         SDL.OptionsView.deactivate();
       }
     },

--- a/app/controller/sdl/RController.js
+++ b/app/controller/sdl/RController.js
@@ -485,6 +485,7 @@ SDL.RController = SDL.SDLController.extend(
         }
       } else {
         FFW.UI.onCommand(element.commandID, this.model.appID);
+        this.model.set('currentSubMenuId', 'top');
         SDL.OptionsView.deactivate();
       }
     },

--- a/app/controller/sdl/RController.js
+++ b/app/controller/sdl/RController.js
@@ -476,7 +476,9 @@ SDL.RController = SDL.SDLController.extend(
 
         // if subMenu
         // activate driver destruction if necessary
-        if (SDL.SDLModel.data.driverDistractionState) {
+        var allowedDepth = SDL.systemCapabilities.driverDistractionCapability.subMenuDepth-1;
+        var activeDepth = SDL.SDLController.model.get('currentMenuDepth');
+        if (SDL.SDLModel.data.driverDistractionState  && activeDepth >= allowedDepth) {
           SDL.DriverDistraction.activate();
         } else {
           this.onSubMenu(element.menuID);

--- a/app/model/sdl/Abstract/AppModel.js
+++ b/app/model/sdl/Abstract/AppModel.js
@@ -390,6 +390,13 @@ SDL.ABSAppModel = Em.Object.extend(
      * @type {Number}
      */
     currentSubMenuId: 'top',
+
+    /**
+     * Count of submenu depth for DD tracking
+     *
+     * @type {Number}
+     */
+    currentMenuDepth: 0,
     /**
      * Return current submenu name
      *
@@ -583,7 +590,7 @@ SDL.ABSAppModel = Em.Object.extend(
     addSubMenu: function(request) {
 
       // parentID is equal to 'top' cause Top level menu ID
-      var parentID = 'top';
+      var parentID = request.params.menuParams.parentID ? request.params.menuParams.parentID : 'top';
       var commands = this.get('commandsList.' + parentID);
       // Magic number is limit of 1000 commands added on one menu
       if (commands.length <= 999) {
@@ -592,7 +599,7 @@ SDL.ABSAppModel = Em.Object.extend(
           menuID: request.params.menuID,
           name: request.params.menuParams.menuName ?
             request.params.menuParams.menuName : '',
-          parent: 0,
+          parent: request.params.menuParams.parentID ? request.params.menuParams.parentID : 0,
           position: request.params.menuParams.position ?
             request.params.menuParams.position : 0,
           icon: request.params.menuIcon ? request.params.menuIcon.value : null

--- a/app/model/sdl/Abstract/AppModel.js
+++ b/app/model/sdl/Abstract/AppModel.js
@@ -403,15 +403,20 @@ SDL.ABSAppModel = Em.Object.extend(
      * @return {String}
      */
     currentSubMenuLabel: function() {
-
-      //Param "top" is Top level menu index
-      var submenu, commands = this.commandsList['top'];
-      for (var i = 0; i < commands.length; i++) {
-        if (commands[i].menuID == this.currentSubMenuId) {
-          submenu = commands[i].name;
+      var commandsList = this.commandsList;
+      var findMenuName = (commands, menuID) => {
+        for (id in commands) {
+          var subMenuCommands = commands[id];
+          for (element of subMenuCommands) {
+            if (element.menuID === menuID) {
+              return element.name;
+            }
+          }
         }
+        return 'Options';
       }
-      return this.get('currentSubMenuId') != 'top' ? submenu : 'Options';
+      return this.get('currentSubMenuId') != 'top' ? 
+        findMenuName(commandsList, this.currentSubMenuId) : 'Options';
     }.property('this.currentSubMenuId'),
     /**
      * Interaction chooses data

--- a/app/model/sdl/Abstract/AppModel.js
+++ b/app/model/sdl/Abstract/AppModel.js
@@ -632,13 +632,20 @@ SDL.ABSAppModel = Em.Object.extend(
      * @param {Number}
      */
     deleteSubMenu: function(menuID) {
-      if (this.commandsList['top'].filterProperty('commandID', menuID)) {
-        this.get('commandsList.top').removeObjects(
-          this.get('commandsList.top').filterProperty('menuID', menuID)
-        );
-        //delete(this.commandsList[menuID]);
+      var commandsList = this.commandsList;
+      for (id in commandsList) {
+        var filteredObjects = commandsList[id].filterProperty('menuID', menuID);
+        if (filteredObjects.length > 0) {
+          commandsList[id].removeObjects(
+            filteredObjects
+          );
+          if (menuID in commandsList) {
+            delete(commandsList[menuID])
+          }
+          return SDL.SDLModel.data.resultCode.SUCCESS;
+        }
       }
-      return SDL.SDLModel.data.resultCode.SUCCESS;
+      return SDL.SDLModel.data.resultCode.INVALID_ID;
     },
     /**
      * SDL UI CreateInteraction response handeler push set of commands to

--- a/app/model/sdl/Abstract/AppModel.js
+++ b/app/model/sdl/Abstract/AppModel.js
@@ -599,7 +599,7 @@ SDL.ABSAppModel = Em.Object.extend(
           menuID: request.params.menuID,
           name: request.params.menuParams.menuName ?
             request.params.menuParams.menuName : '',
-          parent: request.params.menuParams.parentID ? request.params.menuParams.parentID : 0,
+          parent: parentID,
           position: request.params.menuParams.position ?
             request.params.menuParams.position : 0,
           icon: request.params.menuIcon ? request.params.menuIcon.value : null

--- a/app/view/sdl/shared/optionsView.js
+++ b/app/view/sdl/shared/optionsView.js
@@ -94,7 +94,12 @@ SDL.OptionsView = SDL.SDLAbstractView.create(
               len,
               template;
             this.items = [];
-            len = commands.length;
+            if (SDL.SDLModel.data.driverDistractionState) {
+              var ddMaxLength = SDL.systemCapabilities.driverDistractionCapability.menuLength;
+              len = (ddMaxLength > commands.length) ? commands.length : ddMaxLength;
+            } else {
+              len = commands.length;
+            }
             for (i = 0; i < len; i++) {
               if (commands[i].menuID >= 0) {
                 template = 'arrow';
@@ -117,6 +122,19 @@ SDL.OptionsView = SDL.SDLAbstractView.create(
                     target: 'SDL.SDLController',
                     action: 'onCommand',
                     onDown: false
+                  }
+                }
+              );
+            }
+            if (commands.length !== len) {
+              this.items.push(
+                {
+                  type: SDL.Button,
+                  params: {
+                    templateName: "text",
+                    text: "Some Menu Items Are Hidden",
+                    onDown: false,
+                    disabled: true
                   }
                 }
               );

--- a/app/view/sdl/shared/optionsView.js
+++ b/app/view/sdl/shared/optionsView.js
@@ -56,9 +56,22 @@ SDL.OptionsView = SDL.SDLAbstractView.create(
     // Extend deactivate window
     deactivate: function() {
       if (SDL.SDLController.model) {
-        if (SDL.SDLController.model.get('currentSubMenuId') >= 0  && 
-        !SDL.SDLController.model.get('subMenuInitFromApp')) {
-          SDL.SDLController.onSubMenu('top');
+        var currentSubMenuID = SDL.SDLController.model.get('currentSubMenuId');
+        if (currentSubMenuID >= 0  && 
+          !SDL.SDLController.model.get('subMenuInitFromApp')) {
+          var commandsList = SDL.SDLController.model.get('commandsList');
+          var findParentID = (commands, menuID) => {
+            for (id in commands) {
+              var subMenuCommands = commands[id];
+              for (element of subMenuCommands) {
+                if (element.menuID === menuID) {
+                  return element.parent;
+                }
+              }
+            }
+            return 'top';
+          }
+          SDL.SDLController.onSubMenu(findParentID(commandsList, currentSubMenuID));
         } else {
           SDL.SDLController.onSubMenu('top');
           this._super();

--- a/app/view/sdl/shared/optionsView.js
+++ b/app/view/sdl/shared/optionsView.js
@@ -57,7 +57,8 @@ SDL.OptionsView = SDL.SDLAbstractView.create(
     deactivate: function() {
       if (SDL.SDLController.model) {
         var currentSubMenuID = SDL.SDLController.model.get('currentSubMenuId');
-        if (currentSubMenuID >= 0  && 
+        if (currentSubMenuID != 'top' &&
+          currentSubMenuID >= 0  && 
           !SDL.SDLController.model.get('subMenuInitFromApp')) {
           var commandsList = SDL.SDLController.model.get('commandsList');
           var findParentID = (commands, menuID) => {

--- a/capabilities/systemCapabilities.js
+++ b/capabilities/systemCapabilities.js
@@ -65,5 +65,9 @@ SDL.systemCapabilities =
         diagonalScreenSize: 8,
         pixelPerInch: 96,
         scale: 1
+    },
+    driverDistractionCapability: {
+        menuLength: 10,
+        subMenuDepth: 2
     }
 }

--- a/ffw/UIRPC.js
+++ b/ffw/UIRPC.js
@@ -1744,6 +1744,8 @@ FFW.UI = FFW.RPCObserver.create(
      */
     onCommand: function(commandID, appID) {
       Em.Logger.log('FFW.UI.onCommand');
+      var allowedDepth = SDL.systemCapabilities.driverDistractionCapability.subMenuDepth-1;
+      var activeDepth = SDL.SDLController.model.get('currentMenuDepth')
       var JSONMessage = {
         'jsonrpc': '2.0',
         'method': 'UI.OnCommand',
@@ -1888,6 +1890,8 @@ FFW.UI = FFW.RPCObserver.create(
      */
     OnSystemContext: function(systemContextValue, appID, windowID) {
       Em.Logger.log('FFW.UI.OnSystemContext');
+      var allowedDepth = SDL.systemCapabilities.driverDistractionCapability.subMenuDepth-1;
+      var activeDepth = SDL.SDLController.model.get('currentMenuDepth')
       // send repsonse
       var JSONMessage = {
         'jsonrpc': '2.0',


### PR DESCRIPTION
Implements/Fixes [#2048](https://github.com/smartdevicelink/sdl_core/issues/2084) [#2123](https://github.com/smartdevicelink/sdl_core/issues/2123)

This PR is **ready** for review.

### Testing Plan
- Send AddSubMenu with a parentID for an existing submenu
- Enable driver distraction and make sure menu items at index > than the allowed menu limits are hidden.
- Enable driver distraction and make sure subMenus at depth > than the allowed subMenuDepth are disabled.
### Summary
Adds parentID for subMenus.
Enables Driver distraction limits for menu length and sub menu depth.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
