### PR TITLE
SDL-0296 Add ability to show navi streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,30 +2,10 @@
 
 HTML5 based utility to see how the SDL works. It connects via WebSocket to [SDL Core](https://github.com/smartdevicelink/sdl_core)
 
+
 # Getting Started
-A quick guide to installing, configuring, and running HMI.
 
-	1. run SmartDeviceLinkCore
-	2. run chromium-browser [root_of_cloned_sdl_hmi_repo/index.html]
-
-## Simulating signals for LOW_VOLTAGE feature
-In order to simulate UNIX signals used by the LOW_VOLTAGE feature, some additional setup is required
-
-	1. run `deploy_server.sh`
-	2. run the HMI normally
-	3. open the `Exit Application` menu, choose a signal from the menu and press `Send signal`
-
-## PTU With vehicle modem
-In order to get policy table updates using the vehicle modem, some additional setup is required
-
-	1. Run `deploy_server.sh`
-	2. Run the HMI normally
-	3. Click  the `System Request` button
-    4. Select the `PTU using in-vehicle modem` checkbox to enable the feature
-
-## A quick note about dependencies
 This project interacts with [SDL Core](https://github.com/smartdevicelink/sdl_core).
-
 To initialize the git submodules in this project after cloning, run the following commands:
 ```
 cd sdl_hmi
@@ -33,6 +13,28 @@ git submodule init
 git submodule update
 ```
 Alternatively, you can clone this repository with the --recurse-submodules flag.
+
+## Dependencies 
+ 
+ * ffmpeg : `sudo apt install ffmpeg`
+ * Python3,PIP : `sudo apt install python3, python3-pip`
+ * python-ffmpeg : `sudo python3 -m pip install ffmpeg-python`
+ * chroium-browser : `sudo apt install chromium-browser`
+
+## Start HMI
+A quick guide to installing, configuring, and running HMI.
+
+	1. run `deploy_server.sh`
+	2. run SmartDeviceLinkCore
+	2. run chromium-browser [root_of_cloned_sdl_hmi_repo/index.html]
+
+## Simulating signals for LOW_VOLTAGE feature
+I
+	* Open the `Exit Application` menu, choose a signal from the menu and press `Send signal`
+
+## PTU With vehicle modem
+	* Click  the `System Request` button
+    * Select the `PTU using in-vehicle modem` checkbox to enable the feature
 
 ## Note
 SDL HMI utility is only for acquaintance with the SDL project.

--- a/app/controller/InfoController.js
+++ b/app/controller/InfoController.js
@@ -546,6 +546,46 @@ SDL.InfoController = Em.Object.create(
         );
     },
 
+    
+    startStreamingAdapter: function(url) {
+      return new Promise( (resolve, reject) => {
+        let client = FFW.RPCSimpleClient;
+
+        let response_timer = setTimeout(function() {
+          Em.Logger.log('startVideoStreamingAdapter timout');
+          client.unsubscribeFromEvent('StartStreamingAdapter');
+          reject();
+        }, 10000);
+
+        let response_callback = function(params) {
+          Em.Logger.log('StreamingAdapter response');
+          clearTimeout(response_timer);
+          client.unsubscribeFromEvent('StartStreamingAdapter');
+
+          if (params.success == false) {
+            Em.Logger.log('StartStreamingAdapter failed');
+            reject();
+          }
+
+          Em.Logger.log('StartStreamingAdapter succesfully started');
+          resolve(params['stream_endpoint']);
+        }
+
+        let message = {
+          method: 'StartStreamingAdapter',
+          params: {
+            'url' : url
+          }
+        };
+
+        Em.Logger.log(`StartStreamingAdapter request`);
+        client.connect();
+        client.subscribeOnEvent('StartStreamingAdapter', response_callback);
+        client.send(message);
+      });
+    },
+
+
     /**
      * @description Switching on Application
      */

--- a/app/model/sdl/Abstract/Model.js
+++ b/app/model/sdl/Abstract/Model.js
@@ -663,20 +663,24 @@ SDL.SDLModel = Em.Object.extend({
         null) {
 
         SDL.SDLModel.data.naviVideo = document.getElementById('html5Player');
-        SDL.SDLModel.data.naviVideo.src = SDL.SDLController.getApplicationModel(
+        var sdl_stream = SDL.SDLController.getApplicationModel(
           appID
         ).navigationStream;
 
-        var playPromise = SDL.SDLModel.data.naviVideo.play();
-        if (playPromise !== undefined) {
-          playPromise.then(_ => {
-            console.log('Video playback started OK');
-          })
-          .catch(error => {
-            console.log('Video playback start failed: ' + error);
-            SDL.SDLModel.data.naviVideo = null;
-          });
-        }
+        SDL.InfoController.startStreamingAdapter(sdl_stream).then(function(stream_endpoint) {
+          console.log('Adapter promice callback');
+          SDL.SDLModel.data.naviVideo.src = stream_endpoint
+          var playPromise = SDL.SDLModel.data.naviVideo.play();
+          if (playPromise !== undefined) {
+            playPromise.then(_ => {
+              console.log('Video playback started OK');
+            })
+            .catch(error => {
+              console.log('Video playback start failed: ' + error);
+              SDL.SDLModel.data.naviVideo = null;
+            });
+          }
+        });
       }
     },
 


### PR DESCRIPTION
Use ffmpeg to proxy streaming from original SDL output (socket or
pipe) to webm http streaming on 8085 port

Put streaming from ffmpeg to video tag of the navi applicaiton
Part of https://adc.luxoft.com/jira/browse/FORDTCN-4167
