### PR TITLE
Fix menu ordering based on position param

### DIFF
--- a/app/model/sdl/Abstract/AppModel.js
+++ b/app/model/sdl/Abstract/AppModel.js
@@ -529,7 +529,7 @@ SDL.ABSAppModel = Em.Object.extend(
             // Add 4 to the position so the items appear after the default
             // exit options. Default exit options have a request id < 0.
             if (request.id >= 0 && parentID === 'top') {
-              position = position + 4;
+              position += 5; // for exit application commands
             }
             var newItem = {
         		  commandID: request.params.cmdID,
@@ -641,7 +641,7 @@ SDL.ABSAppModel = Em.Object.extend(
             // Add 4 to the position so the items appear after the default
             // exit options. Default exit options have a request id < 0.
             if (request.id >= 0 && parentID === 'top') {
-              position = position + 4;
+              position += 5; // for exit application commands
             }
 
         		var newItem = {

--- a/app/model/sdl/Abstract/AppModel.js
+++ b/app/model/sdl/Abstract/AppModel.js
@@ -528,8 +528,8 @@ SDL.ABSAppModel = Em.Object.extend(
         		  commandID: request.params.cmdID,
         		  name: request.params.menuParams.menuName,
         		  parent: parentID,
-        		  position: request.params.menuParams.position ?
-        		  request.params.menuParams.position : 0,
+        		  position: request.params.menuParams.position !== undefined ?
+        		  request.params.menuParams.position : 1000,
         		  isTemplate:request.params.cmdIcon ?
         		  request.params.cmdIcon.isTemplate ?request.params.cmdIcon.isTemplate : null
         		  : null,
@@ -635,8 +635,8 @@ SDL.ABSAppModel = Em.Object.extend(
         		  name: request.params.menuParams.menuName ?
         		    request.params.menuParams.menuName : '',
         		  parent: parentID,
-        		  position: request.params.menuParams.position ?
-        		    request.params.menuParams.position : 0,
+        		  position: request.params.menuParams.position !== undefined ?
+        		    request.params.menuParams.position : 1000,
         		  icon: request.params.menuIcon ? request.params.menuIcon.value : null
         		};
         		if (SDL.SDLController.getApplicationModel(request.params.appID) &&

--- a/app/model/sdl/Abstract/AppModel.js
+++ b/app/model/sdl/Abstract/AppModel.js
@@ -526,12 +526,15 @@ SDL.ABSAppModel = Em.Object.extend(
     	    if (commands.length <= 999) {
             var position = request.params.menuParams.position !== undefined ?
               request.params.menuParams.position : commands.length;
+            // Add 4 to the position so the items appear after the default
+            // exit options. Default exit options have a request id < 0.
+            if (request.id >= 0 && parentID === 'top') {
+              position = position + 4;
+            }
             var newItem = {
         		  commandID: request.params.cmdID,
         		  name: request.params.menuParams.menuName,
         		  parent: parentID,
-        		  position: request.params.menuParams.position !== undefined ?
-        		  request.params.menuParams.position : 1000,
         		  isTemplate:request.params.cmdIcon ?
         		  request.params.cmdIcon.isTemplate ?request.params.cmdIcon.isTemplate : null
         		  : null,
@@ -635,13 +638,17 @@ SDL.ABSAppModel = Em.Object.extend(
             this.commandsList[request.params.menuID] = [];
             var position = request.params.menuParams.position !== undefined ?
               request.params.menuParams.position : commands.length;
+            // Add 4 to the position so the items appear after the default
+            // exit options. Default exit options have a request id < 0.
+            if (request.id >= 0 && parentID === 'top') {
+              position = position + 4;
+            }
+
         		var newItem = {
         		  menuID: request.params.menuID,
         		  name: request.params.menuParams.menuName ?
         		    request.params.menuParams.menuName : '',
         		  parent: parentID,
-        		  position: request.params.menuParams.position !== undefined ?
-        		    request.params.menuParams.position : 1000,
         		  icon: request.params.menuIcon ? request.params.menuIcon.value : null
             };
             // Insert new item at calculated position

--- a/app/model/sdl/Abstract/AppModel.js
+++ b/app/model/sdl/Abstract/AppModel.js
@@ -524,7 +524,9 @@ SDL.ABSAppModel = Em.Object.extend(
       if (FFW.RPCHelper.isSuccessResultCode(result)) {
           // Magic number is limit of 1000 commands added on one menu
     	    if (commands.length <= 999) {
-        		commands[commands.length] = {
+            var position = request.params.menuParams.position !== undefined ?
+              request.params.menuParams.position : commands.length;
+            var newItem = {
         		  commandID: request.params.cmdID,
         		  name: request.params.menuParams.menuName,
         		  parent: parentID,
@@ -534,14 +536,15 @@ SDL.ABSAppModel = Em.Object.extend(
         		  request.params.cmdIcon.isTemplate ?request.params.cmdIcon.isTemplate : null
         		  : null,
         		  icon: request.params.cmdIcon ? request.params.cmdIcon.value : null
-        		};
+            };
+            // Insert new item at calculated position
+            commands.splice(position, 0, newItem);
         		if (SDL.SDLController.getApplicationModel(request.params.appID) &&
                     SDL.OptionsView.active) {
                         SDL.SDLController.buttonsSort(parentID, this.appID);
                         SDL.OptionsView.commands.refreshItems();
         		}
 
-    		    console.log(commands.length);
     		    if(request.params.cmdIcon) {
     	            var image = request.params.cmdIcon.value;
     		        var length=image.length;
@@ -629,8 +632,10 @@ SDL.ABSAppModel = Em.Object.extend(
         if(FFW.RPCHelper.isSuccessResultCode(result)) {
     	    // Magic number is limit of 1000 commands added on one menu
     	    if (commands.length <= 999) {
-        		this.commandsList[request.params.menuID] = [];
-        		commands[commands.length] = {
+            this.commandsList[request.params.menuID] = [];
+            var position = request.params.menuParams.position !== undefined ?
+              request.params.menuParams.position : commands.length;
+        		var newItem = {
         		  menuID: request.params.menuID,
         		  name: request.params.menuParams.menuName ?
         		    request.params.menuParams.menuName : '',
@@ -638,7 +643,9 @@ SDL.ABSAppModel = Em.Object.extend(
         		  position: request.params.menuParams.position !== undefined ?
         		    request.params.menuParams.position : 1000,
         		  icon: request.params.menuIcon ? request.params.menuIcon.value : null
-        		};
+            };
+            // Insert new item at calculated position
+            commands.splice(position, 0, newItem);
         		if (SDL.SDLController.getApplicationModel(request.params.appID) &&
         		  SDL.OptionsView.active) {
         		    SDL.SDLController.buttonsSort(parentID, this.appID);

--- a/app/view/sdl/shared/optionsView.js
+++ b/app/view/sdl/shared/optionsView.js
@@ -141,8 +141,7 @@ SDL.OptionsView = SDL.SDLAbstractView.create(
                     icon: commands[i].icon,
                     target: 'SDL.SDLController',
                     action: 'onCommand',
-                    onDown: false,
-                    position: commands[i].position
+                    onDown: false
                   }
                 }
               );
@@ -160,21 +159,6 @@ SDL.OptionsView = SDL.SDLAbstractView.create(
                 }
               );
             }
-            this.items.sort((a, b) => {
-              if (a.params.position === undefined) {
-                if (b.params.position === undefined) {
-                  //put both at end
-                  return 0;
-                }
-                //put a at end
-                return 1;
-              }
-              if (b.params.position === undefined) {
-                //put b at end
-                return -1;
-              }
-              return a.params.position - b.params.position
-            });
             this.list.refresh();
           }
         }.observes(

--- a/app/view/sdl/shared/optionsView.js
+++ b/app/view/sdl/shared/optionsView.js
@@ -141,7 +141,8 @@ SDL.OptionsView = SDL.SDLAbstractView.create(
                     icon: commands[i].icon,
                     target: 'SDL.SDLController',
                     action: 'onCommand',
-                    onDown: false
+                    onDown: false,
+                    position: commands[i].position
                   }
                 }
               );
@@ -159,6 +160,21 @@ SDL.OptionsView = SDL.SDLAbstractView.create(
                 }
               );
             }
+            this.items.sort((a, b) => {
+              if (a.params.position === undefined) {
+                if (b.params.position === undefined) {
+                  //put both at end
+                  return 0;
+                }
+                //put a at end
+                return 1;
+              }
+              if (b.params.position === undefined) {
+                //put b at end
+                return -1;
+              }
+              return a.params.position - b.params.position
+            });
             this.list.refresh();
           }
         }.observes(


### PR DESCRIPTION

This PR is **ready** for review.

### Testing Plan
Send a combination of submenus and addcommands with and without the position parameter. Position=0 is placed at front, missing position is placed at end.

### Summary
Add menu sorting based on position. If the position param is undefined, place the items at the end of the list over items that are ordered.
### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
