### PR TITLE
Fix double send of BC.OnReady notification

### DIFF
--- a/app/controller/sdl/Abstract/Controller.js
+++ b/app/controller/sdl/Abstract/Controller.js
@@ -341,8 +341,12 @@ SDL.SDLController = Em.Object.extend(
       for (var i = 0; i < SDL.SDLModel.data.registeredComponents.length; i++) {
         if (SDL.SDLModel.data.registeredComponents[i].type == component) {
           SDL.SDLModel.data.set('registeredComponents.' + i + '.state', true);
-          return;
+          break;
         }
+      }
+
+      if (this.areAllComponentsReady()) {
+        FFW.BasicCommunication.onReady();
       }
     },
     /**
@@ -464,19 +468,19 @@ SDL.SDLController = Em.Object.extend(
       );
     },
     /**
-     * Notify SDLCore that HMI is ready and all components are registered
+     * Checks whether HMI is ready and all components are registered
      *
-     * @type {String}
+     * @return {Boolean}
      */
-    componentsReadiness: function(component) {
+    areAllComponentsReady: function() {
       for (var i = 0; i < SDL.SDLModel.data.registeredComponents.length; i++) {
         if (FLAGS[SDL.SDLModel.data.registeredComponents[i].type] !=
           SDL.SDLModel.data.registeredComponents[i].state) {
-          return;
+          return false;
         }
       }
-      FFW.BasicCommunication.onReady();
-    }.observes('SDL.SDLModel.data.registeredComponents.@each.state'),
+      return true;
+    },
     /**
      * Show VrHelpItems popup with necessary params
      * if VRPopUp is active - show data from Global Properties


### PR DESCRIPTION
Fixes #401 

This PR is **ready** for review.

### Testing Plan
Covered by manual testing

### Summary
Looks like due to EmberJS internal issues observer function was triggered twice for the same state which causes extra sending of OnReady notification. To avoid that issue, components readiness will be perofrmed directly from the caller function.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
