### PR TITLE
Remove unused variables which were causing console errors

### DIFF
--- a/ffw/UIRPC.js
+++ b/ffw/UIRPC.js
@@ -1749,8 +1749,6 @@ FFW.UI = FFW.RPCObserver.create(
      */
     onCommand: function(commandID, appID) {
       Em.Logger.log('FFW.UI.onCommand');
-      var allowedDepth = SDL.systemCapabilities.driverDistractionCapability.subMenuDepth-1;
-      var activeDepth = SDL.SDLController.model.get('currentMenuDepth')
       var JSONMessage = {
         'jsonrpc': '2.0',
         'method': 'UI.OnCommand',
@@ -1895,8 +1893,6 @@ FFW.UI = FFW.RPCObserver.create(
      */
     OnSystemContext: function(systemContextValue, appID, windowID) {
       Em.Logger.log('FFW.UI.OnSystemContext');
-      var allowedDepth = SDL.systemCapabilities.driverDistractionCapability.subMenuDepth-1;
-      var activeDepth = SDL.SDLController.model.get('currentMenuDepth')
       // send repsonse
       var JSONMessage = {
         'jsonrpc': '2.0',


### PR DESCRIPTION
Fixes issue with https://github.com/smartdevicelink/sdl_hmi/pull/383

This PR is **ready** for review.

### Testing Plan
1. Connect app
2. Add VR command for app
3. Start VR session and select new command
4. Verify that `SystemContext` is `MAIN` in app after VR prompt closes

### Summary
Removes unused variables which were causing an error when VR commands were selected

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
