### PR TITLE
delay sending on app exit to ensure onsystemcontext is processed first

### DIFF
--- a/app/controller/sdl/Abstract/Controller.js
+++ b/app/controller/sdl/Abstract/Controller.js
@@ -177,7 +177,8 @@ SDL.SDLController = Em.Object.extend(
         SDL.SDLModel.data.toggleProperty('VRActive');
       }
       if (element.commandID === -2) { //Magic number if predefined VR command USER_EXIT
-        this.userExitAction(element.appID);
+        var that = this;
+        setTimeout( function() { that.userExitAction(element.appID); }, 50);
       } else {
         FFW.VR.onCommand(element.commandID, element.appID, element.grammarID);
       }


### PR DESCRIPTION
This PR is **ready** for review.

### Testing Plan
Manual testing of VR Exit OnHMIStatus sequence

### Issue Summary

When a VR command is selected the `onVRCommand` method is called which first sets `VRActive` to false, and then sends `USER_EXIT` to Core and moves the view back to the app list. Moving the HMI view back to the app list triggers an OnSystemContext notification asynchronously.

There is a lot of delay in setting VRActive, as it has many observers and takes some time to calculate new sysContext property. Meanwhile the OnSystemContext notification is being created. In my testing the sysContext value was updated about 3ms after the OnHMIStatus notification with HMI Level NONE was being sent to Core.

OnHMIStatus sequence currently:
```
OnHMIStatus{ "NOT_AUDIBLE", "FULL", "MAIN" }
OnHMIStatus{ "NOT_AUDIBLE", "FULL", "VRSESSION" }
OnHMIStatus{ "NOT_AUDIBLE", "NONE", "VRSESSION" }
```

### Fix Summary

To fix this data race, I have delayed the call to `Controller.userExitAction` by 50ms which should be enough time for the sysContext to be updated, and not too much time that the user has a laggy experience.

OnHMIStatus sequence with this PR:
```
OnHMIStatus{ "NOT_AUDIBLE", "FULL", "MAIN" }
OnHMIStatus{ "NOT_AUDIBLE", "FULL", "VRSESSION" }
OnHMIStatus{ "NOT_AUDIBLE", "FULL", "MAIN" }
OnHMIStatus{ "NOT_AUDIBLE", "NONE", "MAIN" }
```

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
