### PR TITLE
reply to playTone TTS Speak when over taking it

### DIFF
--- a/app/model/sdl/Abstract/Model.js
+++ b/app/model/sdl/Abstract/Model.js
@@ -1373,6 +1373,12 @@ SDL.SDLModel = Em.Object.extend({
         }
       }
       SDL.TTSPopUp.ActivateTTS(message, files, appID);
+    } else {
+      FFW.TTS.sendError(
+       SDL.SDLModel.data.resultCode.WARNINGS, this.requestId, 'TTS.Speak',
+       'No TTS Chunks provided in Speak request'
+      );
+      this.requestId = null;
     }
   },
 

--- a/ffw/TTSRPC.js
+++ b/ffw/TTSRPC.js
@@ -173,14 +173,6 @@ FFW.TTS = FFW.RPCObserver.create(
               'TTS in progress. Rejected.'
             );
           } else {
-            if (this.requestId) {
-              // playTone does not set TTSPopUp.active
-              FFW.TTS.sendError(
-                SDL.SDLModel.data.resultCode.ABORTED, this.requestId, 'TTS.Speak',
-                'TTS Speak request aborted'
-              );
-            }
-
             this.requestId = request.id;
             SDL.SDLModel.onPrompt(
               request.params.ttsChunks, request.params.appID

--- a/ffw/TTSRPC.js
+++ b/ffw/TTSRPC.js
@@ -173,6 +173,14 @@ FFW.TTS = FFW.RPCObserver.create(
               'TTS in progress. Rejected.'
             );
           } else {
+            if (this.requestId) {
+              // playTone does not set TTSPopUp.active
+              FFW.TTS.sendError(
+                SDL.SDLModel.data.resultCode.ABORTED, this.requestId, 'TTS.Speak',
+                'TTS Speak request aborted'
+              );
+            }
+
             this.requestId = request.id;
             SDL.SDLModel.onPrompt(
               request.params.ttsChunks, request.params.appID


### PR DESCRIPTION
This PR is **ready** for review.

### Testing Plan
Manual, test `Mobile App behavior when interrupted by a push notification` with Alert.playTone param set to true.

### Summary
When a TTS Speak request comes in, the HMI checks if one is already active via the property `SDL.TTSPopUp.active`, but when a mobile app sends an Alert with just `playTone` and no ttsChunks, this property is not set. This PR checks if a request is active via `this.requestId`, simply aborting it and taking over the TTS module for the new request.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
