### PR TITLE
Fix/app permissions list

### DIFF
--- a/ffw/BasicCommunicationRPC.js
+++ b/ffw/BasicCommunicationRPC.js
@@ -365,7 +365,9 @@ FFW.BasicCommunication = FFW.RPCObserver
         }
         if (response.result.method == 'SDL.GetStatusUpdate') {
           Em.Logger.log('SDL.GetStatusUpdate: Response from SDL!');
-          SDL.PopUp.create().appendTo('body').popupActivate(response.result);
+          SDL.PopUp.create().appendTo('body').popupActivate(
+            "Update Status: " + response.result.status, null, false 
+          );
         }
         if (response.result.method == 'BasicCommunication.GetAppProperties') {
           Em.Logger.log('BasicCommunication.GetAppProperties: Response from SDL!');


### PR DESCRIPTION
Fixes [#148](https://github.com/SmartDeviceLink/sdl_hmi/issues/148)

This PR is **ready** for review.

### Summary
Current PR contains an additional check for displaying propper application permissions.
Note: goToStates is removed from permissionsFriendlyMessageUpdate to prevent switching to app permissions after an application is activated.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
