### PR TITLE
Fix nested commands removal

### DIFF
--- a/app/model/sdl/Abstract/AppModel.js
+++ b/app/model/sdl/Abstract/AppModel.js
@@ -667,18 +667,20 @@ SDL.ABSAppModel = Em.Object.extend(
      */
     deleteSubMenu: function(menuID) {
       var commandsList = this.commandsList;
+
       for (id in commandsList) {
         var filteredObjects = commandsList[id].filterProperty('menuID', menuID);
+
         if (filteredObjects.length > 0) {
-          commandsList[id].removeObjects(
-            filteredObjects
-          );
-          if (menuID in commandsList) {
-            delete(commandsList[menuID])
-          }
-          return SDL.SDLModel.data.resultCode.SUCCESS;
+          commandsList[id].removeObjects(filteredObjects);
         }
       }
+
+      if (menuID in commandsList) {
+        delete(commandsList[menuID])
+        return SDL.SDLModel.data.resultCode.SUCCESS;
+      }
+
       return SDL.SDLModel.data.resultCode.INVALID_ID;
     },
     /**


### PR DESCRIPTION
Fixes #414 

This PR is **ready** for review.

### Testing Plan
[Describe how your changes will be tested]

### Summary
In case when commands organized in a tree hierarchy there might be a case when applicaiton deletes command with childs. In that case SDL removes parent command first and then all its childs starting from the bottom one. In case when SDL tries to remove the last child, HMI responds with INVALID_ID because it can't find that node by menu_id as its parent was deleted first.
To fix that issue, logic of commands removal was updated so now HMI responds with SUCCESS if commandsList contain the array by menuID. It makes more sense because parent node could be deleted first.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
