### PR TITLE
Add support for custom menu icon and title

### DIFF
--- a/app/controlls/Button.js
+++ b/app/controlls/Button.js
@@ -221,6 +221,17 @@ SDL.Button = Em.View.extend(Ember.TargetActionSupport,
         '<span>{{view.text}}</span>' +
         '<img class="arrow-ico" src="images/common/arrow_ico.png" />'
       ),
+      arrowShort: Em.Handlebars.compile(
+        '<img {{bindAttr class="view.icon:ico"}} {{bindAttr src="view.icon"}} />' +
+        '<span>{{view.text}}</span>' +
+        '<img class="arrow-ico-short" src="images/common/arrow_ico.png" />'
+      ),
+      arrowShortOverLay: Em.Handlebars.compile(
+        '<img {{bindAttr class="view.icon:ico-overlay"}}  />' +
+        '<img {{bindAttr class="view.icon:ico"}} {{bindAttr src="view.icon"}} />' +
+        '<span>{{view.text}}</span>' +
+        '<img class="arrow-ico-short" src="images/common/arrow_ico.png" />'
+      ),
 
       rightIcon: Em.Handlebars.compile(
         '<img {{bindAttr class="view.icon:ico"}} \

--- a/app/model/sdl/Abstract/Model.js
+++ b/app/model/sdl/Abstract/Model.js
@@ -999,7 +999,10 @@ SDL.SDLModel = Em.Object.extend({
     }
     if (SDL.SDLController.getApplicationModel(params.appID)) {
       for (var i in params) {
-        if (i === 'keyboardProperties') {
+        if (i === "appID") {
+          continue;
+        }
+        else if (i === 'keyboardProperties') {
           mergeKeyboardProperties(params[i]);
         } else {
           SDL.SDLController.getApplicationModel(params.appID).

--- a/app/model/sdl/Abstract/data.js
+++ b/app/model/sdl/Abstract/data.js
@@ -868,7 +868,7 @@ SDL.SDLModelData = Em.Object.create(
                 {
                   "name": "menuTitle",
                   "characterSet": "UTF_8",
-                  "width": 500,
+                  "width": 10,
                   "rows": 1
                 },
                 {

--- a/app/model/sdl/MediaModel.js
+++ b/app/model/sdl/MediaModel.js
@@ -82,11 +82,13 @@ SDL.SDLMediaModel = SDL.ABSAppModel.extend({
     this.set('VRCommands', []);
     this.set('tbtActivate', false);
     this.set('isPlaying', true);
+    this.set('globalProperties', Em.Object.create());
     this.set('globalProperties.helpPrompt', []);
     this.set('globalProperties.timeoutPrompt', []);
     this.set('globalProperties.keyboardProperties', Em.Object.create());
     this.set('globalProperties.keyboardProperties.keyboardLayout', 'QWERTY');
     this.set('globalProperties.keyboardProperties.limitedCharacterList', []);
+    this.set('globalProperties.menuIcon', Em.Object.create());
 
     this.set('commandsList', {'top': []});
     this.set('softButtons', []);

--- a/app/model/sdl/NonMediaModel.js
+++ b/app/model/sdl/NonMediaModel.js
@@ -84,11 +84,13 @@ SDL.SDLNonMediaModel = SDL.ABSAppModel.extend({
     this.set('initialColorScheme.displayLayout', this.displayLayout);
     this.set('VRCommands', []);
     this.set('tbtActivate', false);
+    this.set('globalProperties', Em.Object.create());
     this.set('globalProperties.helpPrompt', []);
     this.set('globalProperties.timeoutPrompt', []);
     this.set('globalProperties.keyboardProperties', Em.Object.create());
     this.set('globalProperties.keyboardProperties.keyboardLayout', 'QWERTY');
     this.set('globalProperties.keyboardProperties.limitedCharacterList', []);
+    this.set('globalProperties.menuIcon', Em.Object.create());
 
     this.set('inactiveWindows', []);
     this.set('backgroundWindows', []);

--- a/app/view/info/nonMediaView.js
+++ b/app/view/info/nonMediaView.js
@@ -166,9 +166,7 @@ SDL.InfoNonMedia = Em.ContainerView.create(
                   SDL.SDLController.model.appID
                 );
               }
-            }.observes('SDL.SDLController.model.softButtons.@each', 
-                       'SDL.SDLController.model.globalProperties.menuTitle',
-                       'SDL.SDLController.model.globalProperties.menuIcon'),
+            }.observes('SDL.SDLController.model.softButtons.@each'),
             updateOptionsButton: function() {
               if (SDL.SDLController.model && SDL.SDLController.model.appID ==
                 SDL.NonMediaController.currentAppId) {

--- a/app/view/info/nonMediaView.js
+++ b/app/view/info/nonMediaView.js
@@ -161,11 +161,6 @@ SDL.InfoNonMedia = Em.ContainerView.create(
 
               if (SDL.SDLController.model && SDL.SDLController.model.appID ==
                 SDL.NonMediaController.currentAppId) {
-                var menuTitle = SDL.SDLController.getApplicationModel(SDL.NonMediaController.currentAppId).globalProperties.menuTitle
-                this.get('content.optionsButton').set('text', menuTitle && menuTitle.length ? menuTitle : 'Options')
-                var menuIcon = SDL.SDLController.getApplicationModel(SDL.NonMediaController.currentAppId).globalProperties.menuIcon
-                this.get('content.optionsButton').set('icon', menuIcon && menuIcon.value && menuIcon.value.length ? menuIcon.value : null)
-                this.get('content.optionsButton').set('templateName', menuIcon && menuIcon.isTemplate ? 'arrowShortOverLay' : 'arrowShort')
                 this.addItems(
                   SDL.SDLController.model.softButtons,
                   SDL.SDLController.model.appID
@@ -174,6 +169,18 @@ SDL.InfoNonMedia = Em.ContainerView.create(
             }.observes('SDL.SDLController.model.softButtons.@each', 
                        'SDL.SDLController.model.globalProperties.menuTitle',
                        'SDL.SDLController.model.globalProperties.menuIcon'),
+            updateOptionsButton: function() {
+              if (SDL.SDLController.model && SDL.SDLController.model.appID ==
+                SDL.NonMediaController.currentAppId) {
+                var menuTitle = SDL.SDLController.model.globalProperties.menuTitle
+                this.get('content.optionsButton').set('text', menuTitle && menuTitle.length ? menuTitle : 'Options')
+                var menuIcon = SDL.SDLController.model.globalProperties.menuIcon
+                this.get('content.optionsButton').set('icon', menuIcon && menuIcon.value && menuIcon.value.length ? menuIcon.value : null)
+                this.get('content.optionsButton').set('templateName', menuIcon && menuIcon.isTemplate ? 'arrowShortOverLay' : 'arrowShort')
+              }
+            }.observes(
+              'SDL.SDLController.model.globalProperties.menuTitle',
+              'SDL.SDLController.model.globalProperties.menuIcon'),
 
             groupName: 'NonMediaView',
 

--- a/app/view/info/nonMediaView.js
+++ b/app/view/info/nonMediaView.js
@@ -161,12 +161,19 @@ SDL.InfoNonMedia = Em.ContainerView.create(
 
               if (SDL.SDLController.model && SDL.SDLController.model.appID ==
                 SDL.NonMediaController.currentAppId) {
+                var menuTitle = SDL.SDLController.getApplicationModel(SDL.NonMediaController.currentAppId).globalProperties.menuTitle
+                this.get('content.optionsButton').set('text', menuTitle && menuTitle.length ? menuTitle : 'Options')
+                var menuIcon = SDL.SDLController.getApplicationModel(SDL.NonMediaController.currentAppId).globalProperties.menuIcon
+                this.get('content.optionsButton').set('icon', menuIcon && menuIcon.value && menuIcon.value.length ? menuIcon.value : null)
+                this.get('content.optionsButton').set('templateName', menuIcon && menuIcon.isTemplate ? 'arrowShortOverLay' : 'arrowShort')
                 this.addItems(
                   SDL.SDLController.model.softButtons,
                   SDL.SDLController.model.appID
                 );
               }
-            }.observes('SDL.SDLController.model.softButtons.@each'),
+            }.observes('SDL.SDLController.model.softButtons.@each', 
+                       'SDL.SDLController.model.globalProperties.menuTitle',
+                       'SDL.SDLController.model.globalProperties.menuIcon'),
 
             groupName: 'NonMediaView',
 
@@ -189,7 +196,8 @@ SDL.InfoNonMedia = Em.ContainerView.create(
                   {
                     text: 'Options',
 
-                    templateName: 'arrow',
+                    classNames: 'softButton',
+                    templateName: 'arrowShort',
 
                     action: 'openCommandsList',
                     target: 'SDL.SDLController'

--- a/app/view/media/sdlmediaView.js
+++ b/app/view/media/sdlmediaView.js
@@ -71,12 +71,21 @@ SDL.sdlView = Em.ContainerView
             refreshItems: function() {
               if (SDL.SDLController.model && SDL.SDLController.model.appID ==
                 SDL.SDLMediaController.currentAppId) {
+                var menuTitle = SDL.SDLController.getApplicationModel(SDL.SDLMediaController.currentAppId).globalProperties.menuTitle
+                this.get('content.optionsButton').set('text', menuTitle && menuTitle.length ? menuTitle : 'Options')
+                var menuIcon = SDL.SDLController.getApplicationModel(SDL.SDLMediaController.currentAppId).globalProperties.menuIcon
+                this.get('content.optionsButton').set('icon', menuIcon && menuIcon.value && menuIcon.value.length ? menuIcon.value : null)
+                this.get('content.optionsButton').set('templateName', menuIcon && menuIcon.isTemplate ? 'arrowShortOverLay' : 'arrowShort')
                 this.addItems(
                   SDL.SDLController.model.softButtons,
                   SDL.SDLController.model.appID
                 );
               }
-            }.observes('SDL.SDLController.model.softButtons.@each'),
+            }.observes(
+              'SDL.SDLController.model.softButtons.@each', 
+              'SDL.SDLController.model.globalProperties.menuTitle',
+              'SDL.SDLController.model.globalProperties.menuIcon',
+              'SDL.SDLController.model.appID'),
             groupName: 'MediaView',
             elementId: 'sdl_view_container_menu',
             content: Em.ContainerView.extend(
@@ -93,7 +102,8 @@ SDL.sdlView = Em.ContainerView
                 optionsButton: SDL.Button.extend(
                   {
                     text: 'Options',
-                    templateName: 'arrow',
+                    classNames: 'softButton',
+                    templateName: 'arrowShort',
                     action: 'openCommandsList',
                     target: 'SDL.SDLController'
                   }

--- a/app/view/media/sdlmediaView.js
+++ b/app/view/media/sdlmediaView.js
@@ -71,21 +71,25 @@ SDL.sdlView = Em.ContainerView
             refreshItems: function() {
               if (SDL.SDLController.model && SDL.SDLController.model.appID ==
                 SDL.SDLMediaController.currentAppId) {
-                var menuTitle = SDL.SDLController.getApplicationModel(SDL.SDLMediaController.currentAppId).globalProperties.menuTitle
-                this.get('content.optionsButton').set('text', menuTitle && menuTitle.length ? menuTitle : 'Options')
-                var menuIcon = SDL.SDLController.getApplicationModel(SDL.SDLMediaController.currentAppId).globalProperties.menuIcon
-                this.get('content.optionsButton').set('icon', menuIcon && menuIcon.value && menuIcon.value.length ? menuIcon.value : null)
-                this.get('content.optionsButton').set('templateName', menuIcon && menuIcon.isTemplate ? 'arrowShortOverLay' : 'arrowShort')
                 this.addItems(
                   SDL.SDLController.model.softButtons,
                   SDL.SDLController.model.appID
                 );
               }
             }.observes(
-              'SDL.SDLController.model.softButtons.@each', 
+              'SDL.SDLController.model.softButtons.@each'),
+            updateOptionsButton: function() {
+              if (SDL.SDLController.model && SDL.SDLController.model.appID ==
+                SDL.SDLMediaController.currentAppId) {
+                var menuTitle = SDL.SDLController.model.globalProperties.menuTitle
+                this.get('content.optionsButton').set('text', menuTitle && menuTitle.length ? menuTitle : 'Options')
+                var menuIcon = SDL.SDLController.model.globalProperties.menuIcon
+                this.get('content.optionsButton').set('icon', menuIcon && menuIcon.value && menuIcon.value.length ? menuIcon.value : null)
+                this.get('content.optionsButton').set('templateName', menuIcon && menuIcon.isTemplate ? 'arrowShortOverLay' : 'arrowShort')
+              }
+            }.observes(
               'SDL.SDLController.model.globalProperties.menuTitle',
-              'SDL.SDLController.model.globalProperties.menuIcon',
-              'SDL.SDLController.model.appID'),
+              'SDL.SDLController.model.globalProperties.menuIcon'),
             groupName: 'MediaView',
             elementId: 'sdl_view_container_menu',
             content: Em.ContainerView.extend(

--- a/app/view/navigationApp/baseNavigationView.js
+++ b/app/view/navigationApp/baseNavigationView.js
@@ -131,6 +131,12 @@ SDL.BaseNavigationView = Em.ContainerView.create(
         }
       }
     },
+    updateOptionsButton: function() {
+      if (SDL.SDLController.model) {
+        var menuTitle = SDL.SDLController.getApplicationModel(SDL.SDLController.model.appID).globalProperties.menuTitle
+        this.get('optionsBtn').set('text', menuTitle && menuTitle.length ? menuTitle : 'Options')
+      }
+    }.observes('SDL.SDLController.model.globalProperties.menuTitle'),
     mainField1: SDL.Label.extend(
       {
         classNames: 'mainField1 mainField',

--- a/capabilities/display_capabilities.js
+++ b/capabilities/display_capabilities.js
@@ -171,7 +171,7 @@ SDL.templateCapabilities = {
                 {
                     "name": "menuTitle",
                     "characterSet": "UTF_8",
-                    "width": 500,
+                    "width": 10,
                     "rows": 1
                 },
                 {
@@ -618,7 +618,7 @@ SDL.templateCapabilities = {
                 {
                     "name": "menuTitle",
                     "characterSet": "UTF_8",
-                    "width": 500,
+                    "width": 12,
                     "rows": 1
                 },
                 {
@@ -1060,7 +1060,7 @@ SDL.templateCapabilities = {
                 {
                     "name": "menuTitle",
                     "characterSet": "UTF_8",
-                    "width": 500,
+                    "width": 15,
                     "rows": 1
                 },
                 {

--- a/css/general.css
+++ b/css/general.css
@@ -716,6 +716,11 @@ button.next-home {
     right: 10px;
 }
 
+.arrow-ico-short {
+    position: absolute;
+    right: 0px;
+}
+
 .right_text {
     float: right;
     margin-right: 5px;


### PR DESCRIPTION
This PR is **ready** for review.

### Testing Plan
Manually test using `SetGlobalProperties` with `menuIcon` and `menuTitle` with multiple apps running.

### Summary
Adds support for the `menuTitle` global property in all templates and `menuIcon` in the media and non-media templates.

Also fixes issue where global properties were not separated by app ID, meaning that changes to the global properties for one app would affect all apps

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
