### PR TITLE
Add check if locationImage is not provided

### DIFF
--- a/app/view/navigationView.js
+++ b/app/view/navigationView.js
@@ -62,7 +62,8 @@ SDL.NavigationView = Em.ContainerView.create(
                   className: 'button',
                   text: SDL.NavigationModel.LocationDetails[i].locationName,
                   disabled: false,
-                  icon: SDL.NavigationModel.LocationDetails[i].locationImage.value,
+                  icon: SDL.NavigationModel.LocationDetails[i].locationImage 
+                    ? SDL.NavigationModel.LocationDetails[i].locationImage.value : '',
                   templateName: SDL.NavigationModel.LocationDetails[i].locationImage
                     ? '' : 'text',
                   action: 'openWayPoint',


### PR DESCRIPTION
An error occurred if locationImage was not included in SendLocation, this adds a check to prevent that error

Fixes #325 when `locationImage` is omitted

This PR is **ready** for review.

### Testing Plan
Manual testing

### Summary
Add null check for locationImage in SendLocation message

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
