### PR TITLE
fix keyboard clear console error

### DIFF
--- a/app/view/sdl/shared/keyboard.js
+++ b/app/view/sdl/shared/keyboard.js
@@ -79,7 +79,7 @@ SDL.Keyboard = SDL.SDLAbstractView.create(
      */
     deactivate: function() {
       this._super();
-      this.searchBar.input.set('value', null);
+      this.searchBar.input.set('value', '');
       this.set('target', null);
     },
     inputChanges: function(element) {


### PR DESCRIPTION
Implements/Fixes https://github.com/smartdevicelink/sdl_hmi/issues/374

This PR is **ready** for review.

### Testing Plan
present keyboard twice and see no errors pressing clear (x) on either keyboard.
bug was only present on second show of keyboard (caused in first deactivate)

### Summary
searchBar.input.value should always be string type

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
