### PR TITLE
Added return statement for early resolve/reject

### DIFF
--- a/app/controller/InfoController.js
+++ b/app/controller/InfoController.js
@@ -423,7 +423,7 @@ SDL.InfoController = Em.Object.create(
       return new Promise( (resolve, reject) => {
         if (!(policyAppID in SDL.InfoController.appPackageDownloadUrlsMap)) {
           Em.Logger.log(`App store: download URL for ${policyAppID} was not found. Assume bundle was installed manually.`);
-          resolve();
+          return resolve();
         }
 
         let download_url = SDL.InfoController.appPackageDownloadUrlsMap[policyAppID];
@@ -443,7 +443,7 @@ SDL.InfoController = Em.Object.create(
 
           if (params.success == false) {
             Em.Logger.log('App store: Bundle downloading was not successful');
-            reject();
+            return reject();
           }
 
           Em.Logger.log('App store: Bundle was downloaded successfully');
@@ -489,7 +489,7 @@ SDL.InfoController = Em.Object.create(
 
           if (params.success == false) {
             Em.Logger.log('App store: Manifest loading was not successful');
-            reject();
+            return reject();
           }
 
           Em.Logger.log('App store: Manifest was loaded successfully');
@@ -524,13 +524,13 @@ SDL.InfoController = Em.Object.create(
         }
         catch {
           Em.Logger.log(`App store: failed to parse JSON content`);
-          reject();
+          return reject();
         }
 
         Em.Logger.log(`App store: manifest parsed successfully`);
         if (!('entrypoint' in bundle_json)) {
           Em.Logger.log(`App store: entrypoint is not specified - use default`);
-          resolve("index.html");
+          return resolve("index.html");
         }
 
         resolve(bundle_json['entrypoint']);

--- a/app/controller/SettingsController.js
+++ b/app/controller/SettingsController.js
@@ -417,7 +417,7 @@ SDL.SettingsController = Em.Object.create(
 
           if (params.success == false) {
             Em.Logger.log('PTU: Downloading PTS was not successful');
-            reject();
+            return reject();
           }
 
           Em.Logger.log('PTU: PTS downloaded successfully');
@@ -492,7 +492,7 @@ SDL.SettingsController = Em.Object.create(
 
           if (params.success == false) {
             Em.Logger.log('PTU: PTU save was not successful');
-            reject();
+            return reject();
           }
 
           Em.Logger.log('PTU: PTU saved successfully');


### PR DESCRIPTION
Fixes #422 

This PR is **ready** for review.

### Testing Plan
Covered by manual test plan

### Summary
There was noticed that in several cases promise statement continues to execute even after resolve()/reject() was called in early if statement. This is because JS has the concept "run to completion". Unless an error is thrown, a function is executed until a return statement or its end is reached.
To fix that, return statements have been placed for cases where resolve/reject is called early. This prevents functions to execute unnecessary code.
Since the return value of the callback is ignored, we can save a line by returning the reject/resolve statement.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
