### PR TITLE
Fix adding of HMI internal commands

### DIFF
--- a/app/model/sdl/Abstract/AppModel.js
+++ b/app/model/sdl/Abstract/AppModel.js
@@ -513,12 +513,17 @@ SDL.ABSAppModel = Em.Object.extend(
         this.commandsList[parentID] = [];
       }
 
-      var commands = this.get('commandsList.' + parentID);
-      result = FFW.RPCHelper.getCustomResultCode(this.appID, 'uiAddCommand');
+      const is_sdl_request = request.id >= 0;
+      let commands = this.get('commandsList.' + parentID);
+      let result = SDL.SDLModel.data.resultCode.SUCCESS;
 
-      if ('DO_NOT_RESPOND' == result) {
-        Em.Logger.log('Do not respond on this request');
-        return;
+      if (is_sdl_request) {
+        result = FFW.RPCHelper.getCustomResultCode(this.appID, 'uiAddCommand');
+
+        if ('DO_NOT_RESPOND' == result) {
+          Em.Logger.log('Do not respond on this request');
+          return;
+        }
       }
 
       if (FFW.RPCHelper.isSuccessResultCode(result)) {
@@ -572,7 +577,7 @@ SDL.ABSAppModel = Em.Object.extend(
               return;
             }
 
-            if (request.id >= 0) {
+            if (is_sdl_request) {
               FFW.UI.sendUIResult(result, request.id, request.method);
             }
     	    } else {


### PR DESCRIPTION
Fixes #433 

This PR is **not ready** for review.

### Testing Plan
Covered by manual test plan

### Summary
HMI internal commands should be added by default for each application and should not depend on HMI settings.
Added check to make an exception for such commands.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
