### PR TITLE
Fix vehicle data issues found during testing

### DIFF
--- a/app/model/sdl/VehicleInfoModel.js
+++ b/app/model/sdl/VehicleInfoModel.js
@@ -468,6 +468,10 @@ SDL.SDLVehicleInfoModel = Em.Object.create(
         FFW.RPCHelper.isSuccessResultCode(customResultCode['SubscribeVehicleData']);
 
       for (var key in message.params){
+        if (key === 'clusterModeStatus') {
+          key = 'clusterModes';
+        }
+
         subscribeVIData[key] = {
           dataType: this.eVehicleDataType[key],
           resultCode: customResultCode.vehicleDataStruct[key],

--- a/app/model/sdl/VehicleInfoModel.js
+++ b/app/model/sdl/VehicleInfoModel.js
@@ -139,7 +139,6 @@ SDL.SDLVehicleInfoModel = Em.Object.create(
       'abs_State': 'VEHICLEDATA_ABS_STATE',
       'turnSignal': 'VEHICLEDATA_TURNSIGNAL',
       'tirePressureValue': 'VEHICLEDATA_TIREPRESSURE_VALUE',
-      'tpms': 'VEHICLEDATA_TPMS',
       'cloudAppVehicleID': 'VEHICLEDATA_CLOUDAPPVEHICLEID',
       'handsOffSteering': 'VEHICLEDATA_HANDSOFFSTEERING',
       'stabilityControlsStatus': 'VEHICLEDATA_STABILITYCONTROLSSTATUS',
@@ -327,7 +326,6 @@ SDL.SDLVehicleInfoModel = Em.Object.create(
         'frontRecommended': 2.2E0,
         'rearRecommended': 2.2E0
       },
-      'tpms': 'TIRES_NOT_TRAINED',
       'cloudAppVehicleID': 'SDLVehicleNo123',
       'displayResolution': {
          'width': 800,


### PR DESCRIPTION
Fixes issue with https://github.com/smartdevicelink/sdl_hmi/pull/394

This PR is **ready** for review.

### Testing Plan
Send SubscribeVehicleData request for all vehicle data items (after allowing them in policies), verify success

### Summary
A check for converting the `clusterModeStatus` value in SubscribeVehicleData was deleted in #394, this PR re-adds that check. In addition, `tpms` was present in the vehicle data model, but is not part of the spec

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
