### PR TITLE
issue #432: Add preferred FPS to VideoStreamingCapability.

### DIFF
--- a/capabilities/systemCapabilities.js
+++ b/capabilities/systemCapabilities.js
@@ -64,7 +64,8 @@ SDL.systemCapabilities =
         hapticSpatialDataSupported: true,
         diagonalScreenSize: 8,
         pixelPerInch: 96,
-        scale: 1
+        scale: 1,
+        preferredFPS: 20
     },
     driverDistractionCapability: {
         menuLength: 10,


### PR DESCRIPTION
Implements issue#432: Add preferred FPS to VideoStreamingCapability.

This PR is **ready** for review.

### Testing Plan
This change will be tested with sdl_core 7.0 + PR at https://github.com/smartdevicelink/sdl_core/pull/3437.

### Summary
This change implements SDL 0274: Add preferred FPS to VideoStreamingCapability.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
