### PR TITLE
Process remaining show message params in case of UNSUPPORTED_RESOURCE

### DIFF
--- a/ffw/UIRPC.js
+++ b/ffw/UIRPC.js
@@ -216,15 +216,13 @@ FFW.UI = FFW.RPCObserver.create(
                 'customPresets' in request.params) {
 
                 if (this.errorResponsePull[request.id].type === 'STATIC') {
-                  this.sendError(SDL.SDLModel.data.resultCode['UNSUPPORTED_RESOURCE'], 
-                                request.id, 
-                                request.method, 
-                                'Image of STATIC type is not supported on HMI. Request was not processed');
-                  return;
+                  this.errorResponsePull[request.id].code =
+                    SDL.SDLModel.data.resultCode['UNSUPPORTED_RESOURCE'];
                 }
-
-                this.errorResponsePull[request.id].code =
-                  SDL.SDLModel.data.resultCode['WARNINGS'];
+                else {
+                  this.errorResponsePull[request.id].code =
+                    SDL.SDLModel.data.resultCode['WARNINGS'];
+                }
               }
             }
             SDL.TurnByTurnView.deactivate();


### PR DESCRIPTION
Fixes issue with https://github.com/smartdevicelink/sdl_hmi/pull/358

This PR is **ready** for review.

### Summary
HMI should still process the rest of the message with an UNSUPPORTED_RESOURCE response

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
