### PR TITLE
Fix response params forwarding

### DIFF
--- a/ffw/BasicCommunicationRPC.js
+++ b/ffw/BasicCommunicationRPC.js
@@ -987,10 +987,25 @@ FFW.BasicCommunication = FFW.RPCObserver
           return;
         }
 
-        const result_response = is_successful_code && (params || !info);
+        let is_successful_response_format = function(is_success) {
+          // Successful response without params, but with not-empty message
+          // should be sent in errorneous format to properly forward info and result code
+          if (is_success && info != null && params == null) {
+            return false;
+          }
+  
+          // Error response with not empty params should be sent in regular format
+          // to properly forward result code and params (but sacrifice info)
+          if (!is_success && params != null) {
+            return true;
+          }
+  
+          // Otherwise use result code calculated according to regular HMI logic
+          return is_success;
+        };
 
         Em.Logger.log('FFW.BC.' + method + 'Response');
-        if (result_response) {
+        if (is_successful_response_format(is_successful_code)) {
           // send response
           var JSONMessage = {
             'jsonrpc': '2.0',

--- a/ffw/NavigationRPC.js
+++ b/ffw/NavigationRPC.js
@@ -499,10 +499,25 @@ FFW.Navigation = FFW.RPCObserver.create(
         return;
       }
 
-      const result_response = is_successful_code && (params || !info);
+      let is_successful_response_format = function(is_success) {
+        // Successful response without params, but with not-empty message
+        // should be sent in errorneous format to properly forward info and result code
+        if (is_success && info != null && params == null) {
+          return false;
+        }
+
+        // Error response with not empty params should be sent in regular format
+        // to properly forward result code and params (but sacrifice info)
+        if (!is_success && params != null) {
+          return true;
+        }
+
+        // Otherwise use result code calculated according to regular HMI logic
+        return is_success;
+      };
 
       Em.Logger.log('FFW.Navigation.' + method + 'Response');
-      if (result_response) {
+      if (is_successful_response_format(is_successful_code)) {
         // send response
         var JSONMessage = {
           'jsonrpc': '2.0',

--- a/ffw/RCRPC.js
+++ b/ffw/RCRPC.js
@@ -406,10 +406,25 @@ FFW.RC = FFW.RPCObserver.create(
         return;
       }
 
-      const result_response = is_successful_code && (params || !info);
+      let is_successful_response_format = function(is_success) {
+        // Successful response without params, but with not-empty message
+        // should be sent in errorneous format to properly forward info and result code
+        if (is_success && info != null && params == null) {
+          return false;
+        }
+
+        // Error response with not empty params should be sent in regular format
+        // to properly forward result code and params (but sacrifice info)
+        if (!is_success && params != null) {
+          return true;
+        }
+
+        // Otherwise use result code calculated according to regular HMI logic
+        return is_success;
+      };
 
       Em.Logger.log('FFW.RC.' + method + 'Response');
-      if (result_response) {
+      if (is_successful_response_format(is_successful_code)) {
         // send response
         var JSONMessage = {
           'jsonrpc': '2.0',

--- a/ffw/TTSRPC.js
+++ b/ffw/TTSRPC.js
@@ -399,10 +399,25 @@ FFW.TTS = FFW.RPCObserver.create(
         return;
       }
 
-      const result_response = is_successful_code && (params || !info);
+      let is_successful_response_format = function(is_success) {
+        // Successful response without params, but with not-empty message
+        // should be sent in errorneous format to properly forward info and result code
+        if (is_success && info != null && params == null) {
+          return false;
+        }
+
+        // Error response with not empty params should be sent in regular format
+        // to properly forward result code and params (but sacrifice info)
+        if (!is_success && params != null) {
+          return true;
+        }
+
+        // Otherwise use result code calculated according to regular HMI logic
+        return is_success;
+      };
 
       Em.Logger.log('FFW.TTS.' + method + 'Response');
-      if (result_response) {
+      if (is_successful_response_format(is_successful_code)) {
         // send response
         var JSONMessage = {
           'jsonrpc': '2.0',

--- a/ffw/UIRPC.js
+++ b/ffw/UIRPC.js
@@ -1769,10 +1769,25 @@ FFW.UI = FFW.RPCObserver.create(
         return;
       }
 
-      const result_response = is_successful_code && (params || !info);
+      let is_successful_response_format = function(is_success) {
+        // Successful response without params, but with not-empty message
+        // should be sent in errorneous format to properly forward info and result code
+        if (is_success && info != null && params == null) {
+          return false;
+        }
+
+        // Error response with not empty params should be sent in regular format
+        // to properly forward result code and params (but sacrifice info)
+        if (!is_success && params != null) {
+          return true;
+        }
+
+        // Otherwise use result code calculated according to regular HMI logic
+        return is_success;
+      };
 
       Em.Logger.log('FFW.UI.' + method + 'Response');
-      if (result_response) {
+      if (is_successful_response_format(is_successful_code)) {
         // send response
         var JSONMessage = {
           'jsonrpc': '2.0',

--- a/ffw/VRRPC.js
+++ b/ffw/VRRPC.js
@@ -404,10 +404,25 @@ FFW.VR = FFW.RPCObserver.create(
         return;
       }
 
-      const result_response = is_successful_code && (params || !info);
+      let is_successful_response_format = function(is_success) {
+        // Successful response without params, but with not-empty message
+        // should be sent in errorneous format to properly forward info and result code
+        if (is_success && info != null && params == null) {
+          return false;
+        }
+
+        // Error response with not empty params should be sent in regular format
+        // to properly forward result code and params (but sacrifice info)
+        if (!is_success && params != null) {
+          return true;
+        }
+
+        // Otherwise use result code calculated according to regular HMI logic
+        return is_success;
+      };
 
       Em.Logger.log('FFW.VR.' + method + 'Response');
-      if (result_response) {
+      if (is_successful_response_format(is_successful_code)) {
         // send response
         var JSONMessage = {
           'jsonrpc': '2.0',

--- a/ffw/VehicleInfoRPC.js
+++ b/ffw/VehicleInfoRPC.js
@@ -267,10 +267,25 @@ FFW.VehicleInfo = FFW.RPCObserver.create(
         return;
       }
 
-      const result_response = is_successful_code && (params || !info);
+      let is_successful_response_format = function(is_success) {
+        // Successful response without params, but with not-empty message
+        // should be sent in errorneous format to properly forward info and result code
+        if (is_success && info != null && params == null) {
+          return false;
+        }
+
+        // Error response with not empty params should be sent in regular format
+        // to properly forward result code and params (but sacrifice info)
+        if (!is_success && params != null) {
+          return true;
+        }
+
+        // Otherwise use result code calculated according to regular HMI logic
+        return is_success;
+      };
 
       Em.Logger.log('FFW.VI.' + method + 'Response');
-      if (result_response) {
+      if (is_successful_response_format(is_successful_code)) {
         // send response
         var JSONMessage = {
           'jsonrpc': '2.0',


### PR DESCRIPTION
Fixes #441 

This PR is **ready** for review.

### Testing Plan
Covered with manual checklist

### Summary
There was noticed a regression that HMI does not forward params in case of error. This is because of complicated and wrong logic of calculation of some corner cases. To avoid that, condition was reformatted as a more readable separate function.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
