### PR TITLE
Align Alert and AlerManeuver view

### DIFF
--- a/app/controller/sdl/Abstract/Controller.js
+++ b/app/controller/sdl/Abstract/Controller.js
@@ -698,7 +698,7 @@ SDL.SDLController = Em.Object.extend(
               SDL.AlertManeuverPopUp.deactivate();
             }, SDL.AlertManeuverPopUp.timeout
           );
-          this.onResetTimeout(element.appID, 'Navigation.AlertManeuver');
+          FFW.TTS.OnResetTimeout(element.appID, 'Navigation.AlertManeuver');
           break;
         }
         case 'SubtleAlertPopUp':

--- a/app/controller/sdl/Abstract/Controller.js
+++ b/app/controller/sdl/Abstract/Controller.js
@@ -758,7 +758,7 @@ SDL.SDLController = Em.Object.extend(
      * Method to close AlertMeneuverPopUp view
      */
     closeAlertMeneuverPopUp: function() {
-      SDL.AlertManeuverPopUp.set('activate', false);
+      SDL.AlertManeuverPopUp.deactivate();
     },
     /**
      * Method to open Turn List view from TBT

--- a/app/view/sdl/AlertManeuverPopUp.js
+++ b/app/view/sdl/AlertManeuverPopUp.js
@@ -55,6 +55,7 @@ SDL.AlertManeuverPopUp = Em.ContainerView.create(
     timer: null,
     timeout: 5000,
     alertManeuerRequestId: 0,
+    isCloseButtonVisible: true,
     /**
      * @desc Defines whether icons paths verified successfully.
      */
@@ -119,6 +120,8 @@ SDL.AlertManeuverPopUp = Em.ContainerView.create(
       {
         text: 'Close',
         classNames: 'closeButton softButton',
+        classNameBindings: [
+          'SDL.AlertManeuverPopUp.isCloseButtonVisible::inactive_state'],
         action: 'closeAlertMeneuverPopUp',
         target: 'SDL.SDLController',
         templateName: 'text'
@@ -215,6 +218,10 @@ SDL.AlertManeuverPopUp = Em.ContainerView.create(
       }
 
       SDL.SDLModel.validateImages(params.appID, callback, imageList);
+
+      if (softButtons.length > 0) {
+        this.set('isCloseButtonVisible', false);
+      }
     },
     /**
      * Deactivate PopUp
@@ -244,6 +251,7 @@ SDL.AlertManeuverPopUp = Em.ContainerView.create(
       this.softbuttons.buttons.rerender();
 
       this.set('iconsAreValid', true);
+      this.set('isCloseButtonVisible', true);
       this.addSoftButtons(message.params);
 
       this.set('activate', true );

--- a/app/view/sdl/AlertManeuverPopUp.js
+++ b/app/view/sdl/AlertManeuverPopUp.js
@@ -122,8 +122,10 @@ SDL.AlertManeuverPopUp = Em.ContainerView.create(
         classNames: 'closeButton softButton',
         classNameBindings: [
           'SDL.AlertManeuverPopUp.isCloseButtonVisible::inactive_state'],
-        action: 'closeAlertMeneuverPopUp',
-        target: 'SDL.SDLController',
+        actionUp: function() {
+          this._super();
+          SDL.SDLController.closeAlertMeneuverPopUp();
+        },
         templateName: 'text'
       }
     ),


### PR DESCRIPTION
Fixes #448 

This PR is **ready** for review.

### Testing Plan
Covered by manual checlist

### Summary
Removed hardcoded Close button from AlertManeuver dialog as default soft buttons may perform absolutely the same action. By that reason, Alert dialog does not contain such button.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
