### PR TITLE
Fix empty OnAppPermissionConsent

### DIFF
--- a/app/controller/SettingsController.js
+++ b/app/controller/SettingsController.js
@@ -183,7 +183,7 @@ SDL.SettingsController = Em.Object.create(
      */
     GetListOfPermissions: function(element) {
       FFW.BasicCommunication.GetListOfPermissions(element.appID);
-      SDL.AppPermissionsView.update(SDL.SDLModelData.externalConsentStatus, 0);
+      SDL.AppPermissionsView.update(SDL.SDLModelData.externalConsentStatus, element.appID);
       SDL.States.goToStates('settings.policies.appPermissions');
     },
     /**

--- a/app/view/settings/policies/appPermissionsView.js
+++ b/app/view/settings/policies/appPermissionsView.js
@@ -73,12 +73,14 @@ SDL.AppPermissionsView = Em.ContainerView.create(
                 }
               );
           }
-          FFW.BasicCommunication.OnAppPermissionConsent(
-            permissions, null, 'GUI', SDL.AppPermissionsView.currentAppId
-          );
+          if (permissions.length > 0) {
+            FFW.BasicCommunication.OnAppPermissionConsent(
+              permissions, null, 'GUI', SDL.AppPermissionsView.currentAppId
+            );
+          }
           SDL.AppPermissionsView.currentAppId = null;
         },
-        goToState: 'policies',
+        goToState: 'policies.appPermissionsList',
         icon: 'images/media/ico_back.png',
         onDown: false
       }


### PR DESCRIPTION
Fixes #446 

This PR is **ready** for review.

### Testing Plan
Covered by manual checklist

### Summary
HMI should not sent empty permission consents to SDL as this is invalid notification according to API. Also, was fixed appID parameter for a selected application.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
