### PR TITLE
Fix/fix template image support for elements

### DIFF
--- a/app/controlls/Button.js
+++ b/app/controlls/Button.js
@@ -187,6 +187,12 @@ SDL.Button = Em.View.extend(Ember.TargetActionSupport,
     templates: {
       text: Em.Handlebars.compile('<span class="text">{{view.text}}</span>'),
 
+      textOverlay: Em.Handlebars.compile(
+        '<img {{bindAttr class="view.icon:ico-overlay"}} />' +
+        '<img {{bindAttr class="view.icon:ico"}} {{bindAttr src="view.icon"}} />' +
+        '<span class="text">{{view.text}}</span>'
+      ),
+
       icon: Em.Handlebars.compile(
         '<img class="ico" \
           {{bindAttr src="view.icon"}} />'

--- a/app/controlls/List.js
+++ b/app/controlls/List.js
@@ -204,6 +204,8 @@ SDL.List = Em.ContainerView.extend({
               }
             );
 
+        element.setMode(SDL.SDLModel.data.imageMode);
+
         // Push element to list
         this.get('childViews').pushObject(element);
       }

--- a/app/controlls/MenuList.js
+++ b/app/controlls/MenuList.js
@@ -83,6 +83,16 @@ SDL.MenuList = Em.ContainerView.extend({
     );
   },
 
+  /** Method setting up display mode for correspond components */
+  setMode: function(mode){
+    var items = this.get('content.childViews');
+
+    for (var i = 0; i < items.length; ++i) {
+      var button = items[i];
+      button.setMode(mode);
+    }
+  },
+
   classNames: [
     'ffw_list_menu'
   ],

--- a/app/view/info/appsView.js
+++ b/app/view/info/appsView.js
@@ -183,6 +183,7 @@ SDL.InfoAppsView = Em.ContainerView.create({
     SDL.InfoAppsView.vehicleHealthReport.setMode(SDL.SDLModel.data.imageMode);
     SDL.InfoAppsView.getDeviceList.setMode(SDL.SDLModel.data.imageMode);
     SDL.InfoAppsView.applicationsStore.setMode(SDL.SDLModel.data.imageMode);
+    SDL.InfoAppsView.listOfApplications.setMode(SDL.SDLModel.data.imageMode);
   }.observes('SDL.SDLModel.data.imageMode')
 }
 );

--- a/app/view/mediaView.js
+++ b/app/view/mediaView.js
@@ -42,12 +42,40 @@ SDL.MediaView = Em.ContainerView.create(
       'volumeMenu',
       'optionsMenu',
       SDL.playerView,
-      SDL.sdlView
+      'sdlView'
     ],
     /** Left Menu view component */
     leftMenu: SDL.LeftMenuView,
     /** Volume Menu view component */
     volumeMenu: SDL.VolumeMenuView,
-    optionsMenu: SDL.audioView
+    optionsMenu: SDL.audioView,
+    sdlView: SDL.sdlView,
+
+    /**
+     * @description Callback for display image mode change.
+     */
+    imageModeChanged: function() { 
+      this.leftMenu.radio.setMode(SDL.SDLModel.data.imageMode);
+      this.leftMenu.cdButton.setMode(SDL.SDLModel.data.imageMode);
+      this.leftMenu.usbButton.setMode(SDL.SDLModel.data.imageMode);
+      this.leftMenu.bluetoothButton.setMode(SDL.SDLModel.data.imageMode);
+      this.leftMenu.lineInButton.setMode(SDL.SDLModel.data.imageMode);
+      this.leftMenu.ipodButton.setMode(SDL.SDLModel.data.imageMode);
+      this.leftMenu.sdlButton.setMode(SDL.SDLModel.data.imageMode);
+
+      this.volumeMenu.currentVolume.currentVolume_minus.setMode(SDL.SDLModel.data.imageMode);
+      this.volumeMenu.currentVolume.currentVolume_plus.setMode(SDL.SDLModel.data.imageMode);
+
+      this.optionsMenu.preferencesButton.optionsButton.setMode(SDL.SDLModel.data.imageMode);
+
+      this.sdlView.innerMenu.setMode(SDL.SDLModel.data.imageMode);
+      this.sdlView.controlls.Controls.PrevTrackButton.setMode(SDL.SDLModel.data.imageMode);
+      this.sdlView.controlls.Controls.PlayButton.setMode(SDL.SDLModel.data.imageMode);
+      this.sdlView.controlls.Controls.NextTrackButton.setMode(SDL.SDLModel.data.imageMode);
+
+      this.sdlView.controlls.tuneButtons.wrapper.get('childViews').forEach( (view) => {
+        view.setMode(SDL.SDLModel.data.imageMode);
+      });
+    }.observes('SDL.SDLModel.data.imageMode')
   }
 );

--- a/app/view/navigationView.js
+++ b/app/view/navigationView.js
@@ -54,6 +54,7 @@ SDL.NavigationView = Em.ContainerView.create(
         itemGenerator: function() {
           var items = [];
           for (var i = 0; i < SDL.NavigationModel.LocationDetails.length; i++) {
+            const img = SDL.NavigationModel.LocationDetails[i].locationImage;
             items.push(
               {
                 type: SDL.Button,
@@ -62,10 +63,8 @@ SDL.NavigationView = Em.ContainerView.create(
                   className: 'button',
                   text: SDL.NavigationModel.LocationDetails[i].locationName,
                   disabled: false,
-                  icon: SDL.NavigationModel.LocationDetails[i].locationImage 
-                    ? SDL.NavigationModel.LocationDetails[i].locationImage.value : '',
-                  templateName: SDL.NavigationModel.LocationDetails[i].locationImage
-                    ? '' : 'text',
+                  icon: img ? img.value : '',
+                  templateName: img && img.isTemplate ? 'textOverlay' : '',
                   action: 'openWayPoint',
                   target: 'SDL.NavigationController'
                 }

--- a/css/media.css
+++ b/css/media.css
@@ -105,7 +105,6 @@
     position: relative;
     height: 50px;
     cursor: pointer;
-    background: url(../images/media/ls-item_bg.png) no-repeat;
 }
 
 .media-ls-item.active_state {
@@ -986,7 +985,6 @@
     height: 98px;
     border-right: 1px solid #393939;
     cursor: pointer;
-    background: url(../images/media/cd-prev-btn.png) no-repeat;
 }
 
 .bc-item-big.prevcd.pressed, .bc-item-big.prevusb.pressed,
@@ -1003,7 +1001,6 @@
     height: 98px;
     border-right: 1px solid #393939;
     cursor: pointer;
-    background: url(../images/media/cd_play_btn.png) no-repeat;
     top: 0px;
     position: absolute;
     left: 156px;
@@ -1058,7 +1055,6 @@
     width: 154px;
     height: 98px;
     cursor: pointer;
-    background: url(../images/media/cd-next-btn.png) no-repeat;
     top: 0px;
     position: absolute;
     left: 314px;


### PR DESCRIPTION
Fixes #457 and #458 

This PR is **ready** for review.

### Testing Plan
Covered by manual checklist

### Summary
There was missing button template type for a left text overlay. Also, template style was not applied when list items were
constructed initially.
Added image mode support for more missing elements.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
