### PR TITLE
Fix unnecessary button events from bottom view

### DIFF
--- a/app/view/sdl/VRPopUp.js
+++ b/app/view/sdl/VRPopUp.js
@@ -73,8 +73,14 @@ SDL.VRPopUp = Em.ContainerView.create(
           this.get('listOfCommands.list.childViews').pushObject(
             SDL.Button.create(
               {
-                action: isExit ? 'onVRCommand' : 'onActivateSDLApp',
-                target: 'SDL.SDLController',
+                actionUp: function() {
+                  if (this.isExitAction) {
+                    SDL.SDLController.onVRCommand(this);
+                  } else {
+                    SDL.SDLController.onActivateSDLApp(this);
+                  }
+                },
+                isExitAction: isExit,
                 appID: appID,
                 commandID: cmdID,
                 text: vrCommands[i],
@@ -89,8 +95,13 @@ SDL.VRPopUp = Em.ContainerView.create(
           this.get('listOfCommands.list.childViews').pushObject(
             SDL.Button.create(
               {
-                action: type == 'Command' ? 'onVRCommand' : 'VRPerformAction',
-                target: 'SDL.SDLController',
+                actionUp: function() {
+                  if (this.type == 'Command') {
+                    SDL.SDLController.onVRCommand(this);
+                  } else {
+                    SDL.SDLController.VRPerformAction(this);
+                  }
+                },
                 appID: appID,
                 grammarID: grammarID,
                 commandID: cmdID,
@@ -224,9 +235,9 @@ SDL.VRPopUp = Em.ContainerView.create(
             params: {
               //templateName: template,
               text: 'Help',
-              target: 'SDL.SDLController',
-              action: 'vrHelpAction',
-              onDown: false
+              actionUp: function() {
+                SDL.SDLController.vrHelpAction();
+              }
             }
           }
         ]


### PR DESCRIPTION
Fixes #459 

This PR is **ready** for review.

### Testing Plan
Covered by manual checklist

### Summary
There was noticed an issue that HMI captures ButtonUp and click events in case when button on the upper view was clicked,
view closed and there is another button on the lower view. In that case, unexpected events for these buttons on the lower
view will be raised.
To fix that, buttonDown actions on the VR popup have been replaced with buttonUp action which prevents view closure before all events are captured.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
