### PR TITLE
Do not reset time when countRate is changed

### DIFF
--- a/app/model/sdl/MediaModel.js
+++ b/app/model/sdl/MediaModel.js
@@ -258,7 +258,13 @@ SDL.SDLMediaModel = SDL.ABSAppModel.extend({
     this.currTime = 0;
     this.startTimer();
   }.observes('this.startTime',
-    'this.endTime',
+    'this.endTime'),
+
+  changeRate: function() {
+
+    clearInterval(this.timer);
+    this.startTimer();
+  }.observes(
     'this.countRate'),
 
   /**


### PR DESCRIPTION
Fixes issue with #469 

This PR is **ready** for review.

### Testing Plan
Send PAUSE and RESUME SetMediaClockTimer events with different countRates

### Summary
Fix issue where the timer was reset when countRate was changed

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
