### PR TITLE
Add missing subtle alert text field capabilities

### DIFF
--- a/ffw/UIRPC.js
+++ b/ffw/UIRPC.js
@@ -220,7 +220,7 @@ FFW.UI = FFW.RPCObserver.create(
                 request.params.templateConfiguration.nightColorScheme)) {
                   sendCapabilityUpdated = true;
               }
-          }
+            }
             if(appModel.onSDLUIShow(request.params) === SDL.SDLModel.data.resultCode.REJECTED) {
               this.sendError(SDL.SDLModel.data.resultCode.REJECTED, request.id, request.method,
                     "Widget is duplicating other window. Rejecting UI.Show request.");
@@ -1197,6 +1197,24 @@ FFW.UI = FFW.RPCObserver.create(
                           },
                           {
                             'name': 'phoneNumber',
+                            'characterSet': 'UTF_8',
+                            'width': 500,
+                            'rows': 1
+                          },
+                          {
+                            'name': 'subtleAlertText1',
+                            'characterSet': 'UTF_8',
+                            'width': 500,
+                            'rows': 1
+                          },
+                          {
+                            'name': 'subtleAlertText2',
+                            'characterSet': 'UTF_8',
+                            'width': 500,
+                            'rows': 1
+                          },
+                          {
+                            'name': 'subtleAlertSoftButtonText',
                             'characterSet': 'UTF_8',
                             'width': 500,
                             'rows': 1


### PR DESCRIPTION
Add text field capabilities missing from #421 

This PR is **ready** for review.

### Testing Plan
Check for subtle alert text fields in `systemCapabilities.displayCapabilities[0].windowCapabilities[0].textFields` field of GetSystemCapability(DISPLAYS) request

### Summary
Add subtle alert text field names missing from window capabilities

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
