### PR TITLE
Display timeToDestination field in TBT view

### DIFF
--- a/app/view/sdl/shared/turnByTurnView.js
+++ b/app/view/sdl/shared/turnByTurnView.js
@@ -103,6 +103,14 @@ SDL.TurnByTurnView = SDL.SDLAbstractView.create(
               );
               break;
             }
+            case 'timeToDestination':
+            {
+              this.set(
+                'timeToDestinationtext',
+                naviParams.navigationTexts[i].fieldText
+              );
+              break;
+            }
           }
         }
         this.softButtons.addItems(naviParams.softButtons, appID);
@@ -131,7 +139,6 @@ SDL.TurnByTurnView = SDL.SDLAbstractView.create(
         this.set(
           'distanceToManeuverScaletext', naviParams.distanceToManeuverScale
         );
-        this.set('timeToDestinationtext', naviParams.timeToDestination);
         this.set('activeTBT', true);
       }
     },


### PR DESCRIPTION
Fixes issue with Turn By Turn view

This PR is **ready** for review.

### Testing Plan
Send ShowConstantTBT with `navigationText1`, `navigationText2`, and `timeToDestination` included. The HMI should display all of these fields in the Turn By Turn view

### Summary
Fixes issue where timeToDestination field was not displayed in TBT view

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
