### PR TITLE
Reset user choice for input mask after submitting or closing keyboard

### DIFF
--- a/app/controller/sdl/KeyboardController.js
+++ b/app/controller/sdl/KeyboardController.js
@@ -282,10 +282,6 @@ SDL.KeyboardController = Em.Object.create({
      */
     toggleMaskingOption: function() {
       SDL.KeyboardController.toggleProperty('maskCharacters');
-      SDL.SDLController.model.set('maskInputCharactersUserChoice', SDL.KeyboardController.maskCharacters);
-      if (SDL.SDLController.model) {
-        SDL.KeyboardController.sendInputKeyMaskNotification(SDL.SDLController.model.appID);
-      }
       SDL.KeyboardController.updateInputMasking();
     },
 
@@ -321,6 +317,10 @@ SDL.KeyboardController = Em.Object.create({
      * of internal controller flags
      */
     updateInputMasking: function() {
+      if (SDL.SDLController.model) {
+        SDL.SDLController.model.set('maskInputCharactersUserChoice', SDL.KeyboardController.maskCharacters);
+        SDL.KeyboardController.sendInputKeyMaskNotification(SDL.SDLController.model.appID);
+      }
       if (SDL.Keyboard) {
         if (SDL.KeyboardController.maskCharacters) {
           SDL.Keyboard.searchBar.input.type = 'password';

--- a/app/view/sdl/shared/keyboard.js
+++ b/app/view/sdl/shared/keyboard.js
@@ -51,6 +51,12 @@ SDL.Keyboard = SDL.SDLAbstractView.create(
      * @param {Object}
      */
     activate: function(element) {
+      if (SDL.SDLController.model &&
+          SDL.SDLController.model.globalProperties.keyboardProperties && 
+          SDL.SDLController.model.globalProperties.keyboardProperties.maskInputCharacters == 'USER_CHOICE_INPUT_KEY_MASK') {
+        SDL.KeyboardController.set('maskCharacters', true);
+        SDL.KeyboardController.updateInputMasking();
+      }
       if (element) {
         this.set('active', true);
         SDL.KeyboardController.set('target', element);


### PR DESCRIPTION
Fixes issue with #474 

This PR is **ready** for review.

### Testing Plan
Test repeated KEYBOARD interactions with USER_CHOICE_INPUT_MASK, verify that the mask is always enabled by default with this property

### Summary
Reset user choice for input mask after submitting or closing keyboard

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
