### PR TITLE
kill running webengine app when it is uninstalled

### DIFF
--- a/app/controller/InfoController.js
+++ b/app/controller/InfoController.js
@@ -247,6 +247,16 @@ SDL.InfoController = Em.Object.create(
 
       // Drop pending properties if notification received during Set request
       this.set('editedAppPropertiesToApply', null);
+
+      if (!new_properties.enabled 
+          && new_properties.policyAppID in SDL.SDLModel.webApplicationFramesMap) {
+        let frame = SDL.SDLModel.webApplicationFramesMap[new_properties.policyAppID];
+        const web_engine_view = document.getElementById("webEngineView");
+        if (web_engine_view) {
+          web_engine_view.removeChild(frame);
+        }
+        delete SDL.SDLModel.webApplicationFramesMap[new_properties.policyAppID];
+      }
     },
 
     /**

--- a/app/controller/InfoController.js
+++ b/app/controller/InfoController.js
@@ -231,6 +231,16 @@ SDL.InfoController = Em.Object.create(
     onAppPropertiesNotification: function(new_properties) {
       let updated_properties = this.updateAppProperties(new_properties);
 
+      if (!new_properties.enabled 
+          && new_properties.policyAppID in SDL.SDLModel.webApplicationFramesMap) {
+        let frame = SDL.SDLModel.webApplicationFramesMap[new_properties.policyAppID];
+        const web_engine_view = document.getElementById("webEngineView");
+        if (web_engine_view) {
+          web_engine_view.removeChild(frame);
+        }
+        delete SDL.SDLModel.webApplicationFramesMap[new_properties.policyAppID];
+      }
+
       var current_policy_app_id = SDL.WebAppSettingsView.editorAppSettings.policyAppID;
       if (current_policy_app_id != updated_properties.policyAppID) {
         // Don't refresh displayed properties for a different app
@@ -247,16 +257,6 @@ SDL.InfoController = Em.Object.create(
 
       // Drop pending properties if notification received during Set request
       this.set('editedAppPropertiesToApply', null);
-
-      if (!new_properties.enabled 
-          && new_properties.policyAppID in SDL.SDLModel.webApplicationFramesMap) {
-        let frame = SDL.SDLModel.webApplicationFramesMap[new_properties.policyAppID];
-        const web_engine_view = document.getElementById("webEngineView");
-        if (web_engine_view) {
-          web_engine_view.removeChild(frame);
-        }
-        delete SDL.SDLModel.webApplicationFramesMap[new_properties.policyAppID];
-      }
     },
 
     /**


### PR DESCRIPTION
This PR is **ready** for review.

### Testing Plan
activate a webengine app and then uninstall, check app is no longer running

### Summary
when webengine app is set to enabled false, check that it is no longer running on HMI

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
