### PR TITLE
Remove references to outdated event functions

### DIFF
--- a/app/controller/sdl/RController.js
+++ b/app/controller/sdl/RController.js
@@ -33,31 +33,6 @@
 
 SDL.RController = SDL.SDLController.extend(
   {
-    onEventChanged: function(reason, status) {
-      switch (reason) {
-        case 'phoneCall':
-        {
-          FFW.BasicCommunication.OnPhoneCall(status);
-          break;
-        }
-        case 'emergencyEvent':
-        {
-          FFW.BasicCommunication.OnEmergencyEvent(status);
-          break;
-        }
-        case 'onDeactivateHMI':
-        {
-          FFW.BasicCommunication.OnDeactivateHMI(status);
-          break;
-        }
-        default:
-        {
-          this._super(reason, status);
-          return;
-        }
-      }
-    },
-
    onButtonPressEvent: function(params) {
       var result_struct = {
         resultCode: SDL.SDLModel.data.resultCode.SUCCESS,

--- a/ffw/BasicCommunicationRPC.js
+++ b/ffw/BasicCommunicationRPC.js
@@ -1387,23 +1387,6 @@ FFW.BasicCommunication = FFW.RPCObserver
         this.sendMessage(JSONMessage);
       },
       /**
-       * Sender: HMI->SDL. When: upon phone-call event started or ended
-       *
-       * @params {Boolean}
-       */
-      OnPhoneCall: function(isActive) {
-        Em.Logger.log('FFW.BasicCommunication.OnPhoneCall');
-        // send request
-        var JSONMessage = {
-          'jsonrpc': '2.0',
-          'method': 'BasicCommunication.OnPhoneCall',
-          'params': {
-            'isActive': isActive
-          }
-        };
-        this.sendMessage(JSONMessage);
-      },
-      /**
        * Initiated by HMI user. In response optional list of found devices -
        * if not provided, not were found.
        */
@@ -1491,23 +1474,6 @@ FFW.BasicCommunication = FFW.RPCObserver
         this.sendMessage(JSONMessage);
       },
       /**
-       * Notifies if audio state was changed
-       *
-       * @param {Boolean} enabled
-       */
-      OnEmergencyEvent: function(enabled) {
-        Em.Logger.log('FFW.BasicCommunication.OnEmergencyEvent');
-        // send repsonse
-        var JSONMessage = {
-          'jsonrpc': '2.0',
-          'method': 'BasicCommunication.OnEmergencyEvent',
-          'params': {
-            'enabled': enabled
-          }
-        };
-        this.sendMessage(JSONMessage);
-      },
-      /**
        * Initiated by HMI.
        */
       OnSystemRequest: function(type, fileName, url, appID, subType) {
@@ -1537,23 +1503,6 @@ FFW.BasicCommunication = FFW.RPCObserver
           JSONMessage.params.requestSubType = subType;
         }
 
-        this.sendMessage(JSONMessage);
-      },
-      /**
-       * OnDeactivateHMI notification sender
-       * @param value
-       * @constructor
-       */
-      OnDeactivateHMI: function(value) {
-        Em.Logger.log('FFW.BasicCommunication.OnDeactivateHMI');
-        // send request
-        var JSONMessage = {
-          'jsonrpc': '2.0',
-          'method': 'BasicCommunication.OnDeactivateHMI',
-          'params': {
-            'isDeactivated': value
-          }
-        };
         this.sendMessage(JSONMessage);
       },
       /**


### PR DESCRIPTION

This PR is **ready** for review.

### Testing Plan
Test EmergencyEvent, DeactivateHMI, and PhoneCall events, verify that OnEventChanged notifications are sent for each event

### Summary
"OnPhoneCall", "OnEmergencyEvent", and "OnDeactivateHMI" were replaced by "OnEventChanged" in SDL Core 4.1.0, this PR removes any existing references to these RPCs

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
