### PR TITLE
send touch event CANCEL when touch in progress and leave context MAIN

### DIFF
--- a/ffw/UIRPC.js
+++ b/ffw/UIRPC.js
@@ -2074,6 +2074,13 @@ FFW.UI = FFW.RPCObserver.create(
      */
     OnSystemContext: function(systemContextValue, appID, windowID) {
       Em.Logger.log('FFW.UI.OnSystemContext');
+
+      if (FLAGS.TOUCH_EVENT_STARTED && systemContextValue != 'MAIN'
+          && appID == SDL.SDLController.model.appID) {
+        FLAGS.TOUCH_EVENT_STARTED = false;
+        FFW.UI.onTouchEvent('CANCEL', [{ id: 0, ts: [parseInt(performance.now())], c: [{ x: 0, y: 0 }] }]);
+      }
+
       // send repsonse
       var JSONMessage = {
         'jsonrpc': '2.0',


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_hmi/issues/497

This PR is **ready** for review.

### Testing Plan
drag mouse on navigation screen down off template, notice last touch event sent was MOVE
send Alert/CloseApp/OpenMenu/anything that will change system context from app
see app received OnTouchEvent CANCEL

### Summary
a touch event that was interrupted will likely come to app as incorrect gesture without the CANCEL

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
