### PR TITLE
Fix/OnVehicleData for clusterModeStatus param

### DIFF
--- a/app/controller/sdl/Abstract/Controller.js
+++ b/app/controller/sdl/Abstract/Controller.js
@@ -447,7 +447,8 @@ SDL.SDLController = Em.Object.extend(
                   SDL.SDLVehicleInfoModel.vehicleData[i],
                   parsedData[i]
                 )) {
-              params[i] = parsedData[i];
+              let paramKey = (i === "clusterModes") ? "clusterModeStatus" : i;
+              params[paramKey] = parsedData[i];
             }
           }
           SDL.SDLVehicleInfoModel.vehicleData = parsedData;


### PR DESCRIPTION
Fixes #493 

This PR is **ready** for review.

### Testing Plan

- From the app, send `SubscribeVehicleData` with param `clusterModeStatus` set to true.
- In the sdl_hmi, open the vehicle data editor window (Vehicle Info > Edit vehicle data)
- Under the `clusterModes` parameter, change the value of the `powerModeActive` field and click Save

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
