### PR TITLE
Menu tertiary css alignment

### DIFF
--- a/css/general.css
+++ b/css/general.css
@@ -124,10 +124,10 @@ div.glider-slide {
 }
 
 .ffw-button .end-info {
-    position: relative;
     display: flex;
     justify-content: flex-end;
     flex-grow: 4;
+    right: 0px;
 }
 
 .ffw-button .relative-r-0 {


### PR DESCRIPTION
Fixes #508 
This PR is **ready** for review.

### Testing Plan
Send Add command with all fields populated (secondary image + tertiary text included). Use a decently long string for tertiary text param.

### Summary
Fix CSS where a long tertiary text would push the Image out of the menu item div.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
