### PR TITLE
Fix/redunant keyboard mask notiication

### DIFF
--- a/app/model/sdl/Abstract/Model.js
+++ b/app/model/sdl/Abstract/Model.js
@@ -1082,10 +1082,6 @@ SDL.SDLModel = Em.Object.extend({
         } else {
           model.set('globalProperties.keyboardProperties.' + name, default_properties[name]);
         }
-
-        if (name === 'maskInputCharacters') {
-          SDL.KeyboardController.sendInputKeyMaskNotification(params.appID);
-        }
       }
     }
 

--- a/css/general.css
+++ b/css/general.css
@@ -124,10 +124,10 @@ div.glider-slide {
 }
 
 .ffw-button .end-info {
-    position: relative;
     display: flex;
     justify-content: flex-end;
     flex-grow: 4;
+    right: 0px;
 }
 
 .ffw-button .relative-r-0 {


### PR DESCRIPTION
Implements/Fixes #506 

This PR is **Ready** for review.

### Testing Plan
Send SetGlobal Properties with keyboard input mask. Verify hmi only sends one notification.
### Summary
Remove redundant keyboard mask notification from set global properties.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
