### PR TITLE
Fix HMI shows wrong resolutions in a drop-down list with resolutions in case multiple apps

### DIFF
--- a/app/controller/NavigationController.js
+++ b/app/controller/NavigationController.js
@@ -465,7 +465,7 @@ SDL.NavigationController = Em.Object.create(
      * @return {Array} list of capabilities
      */
     getVideoStreamingCapabilitiesList: function() {
-      const capabilities_array = SDL.NavigationModel.resolutionsList;
+      const capabilities_array = SDL.SDLController.model ? SDL.SDLController.model.resolutionsList : null;
       let list_to_display = [];
 
       if (Array.isArray(capabilities_array)) {
@@ -488,8 +488,8 @@ SDL.NavigationController = Em.Object.create(
 
       if (index >= 0) {
         Em.Logger.log(`Switching video streaming preset to: ${preset_name}`);
-        this.model.set('resolutionIndex', index);
-        const capability_to_switch = this.model.resolutionsList[index];
+        SDL.SDLController.model.set('resolutionIndex', index);
+        const capability_to_switch = SDL.SDLController.model.resolutionsList[index];
         let capabilities_to_send = {};
 
         if (capability_to_switch.preferredResolution) {

--- a/app/model/NavigationModel.js
+++ b/app/model/NavigationModel.js
@@ -40,16 +40,6 @@ SDL.NavigationModel = Em.Object.create({
   appReqPull: [],
 
   /**
-   * List of resolutions to display on navi view
-   */
-  resolutionsList: [],
-
-  /**
-   * Index of selected resolution on navi view
-   */
-  resolutionIndex: 0,
-
-  /**
    * Start navigation point
    */
   startLoc: '98 Walker St, New York, NY 10013, USA',

--- a/app/model/sdl/Abstract/AppModel.js
+++ b/app/model/sdl/Abstract/AppModel.js
@@ -224,6 +224,14 @@ SDL.ABSAppModel = Em.Object.extend(
      */
     navigationAudioStream: null,
     /**
+     * List of resolutions to display on navi view
+     */
+    resolutionsList: [],
+    /**
+     * Index of selected resolution on navi view
+     */
+    resolutionIndex: 0,
+    /**
      * Application video configuration parameters
      *
      * @type {Object}
@@ -537,6 +545,10 @@ SDL.ABSAppModel = Em.Object.extend(
       }
 
       this.set('maskInputCharactersUserChoice', true);
+
+      this.set('resolutionsList',
+        SDL.systemCapabilities.videoStreamingCapability.additionalVideoStreamingCapabilities
+      );
     },
     /**
      * @description Gets app default keyboard global properties

--- a/app/model/sdl/Abstract/Model.js
+++ b/app/model/sdl/Abstract/Model.js
@@ -215,7 +215,7 @@ SDL.SDLModel = Em.Object.extend({
     if (is_image_type && app_model) {
       result = app_model.onImageRemoved(params.fileName);
 
-      const cached_index = app_model.cachedIconFileNamesList.indexOf(fileName);
+      const cached_index = app_model.cachedIconFileNamesList.indexOf(params.fileName);
       if (cached_index >= 0) {
         app_model.cachedIconFileNamesList.splice(cached_index, 1);
       }

--- a/app/model/sdl/Abstract/Model.js
+++ b/app/model/sdl/Abstract/Model.js
@@ -709,8 +709,8 @@ SDL.SDLModel = Em.Object.extend({
 
         Em.Logger.log('Set params from VideoConfig');
 
-        var width = SDL.NavigationModel.resolutionsList[SDL.NavigationModel.resolutionIndex].preferredResolution.resolutionWidth;
-        var height = SDL.NavigationModel.resolutionsList[SDL.NavigationModel.resolutionIndex].preferredResolution.resolutionHeight;
+        var width = app_model.resolutionsList[app_model.resolutionIndex].preferredResolution.resolutionWidth;
+        var height = app_model.resolutionsList[app_model.resolutionIndex].preferredResolution.resolutionHeight;
 
         SDL.SDLModel.data.naviVideo.style.setProperty("width",width + "px");
         SDL.SDLModel.data.naviVideo.style.setProperty("height",height + "px");

--- a/app/model/sdl/Abstract/Model.js
+++ b/app/model/sdl/Abstract/Model.js
@@ -1082,10 +1082,6 @@ SDL.SDLModel = Em.Object.extend({
         } else {
           model.set('globalProperties.keyboardProperties.' + name, default_properties[name]);
         }
-
-        if (name === 'maskInputCharacters') {
-          SDL.KeyboardController.sendInputKeyMaskNotification(params.appID);
-        }
       }
     }
 

--- a/app/view/navigationApp/baseNavigationView.js
+++ b/app/view/navigationApp/baseNavigationView.js
@@ -48,12 +48,6 @@ SDL.BaseNavigationView = Em.ContainerView.create(
       'navSubButtons',
       'optionsBtn'
     ],
-    appLoaded: function() {
-      SDL.NavigationModel.set(
-        'resolutionsList',
-        SDL.systemCapabilities.videoStreamingCapability.additionalVideoStreamingCapabilities
-      );
-    }.observes('SDL.appReady'),
     update: function() {
       var naviParams = SDL.SDLModel.data.constantTBTParams;
       if (naviParams) {
@@ -180,19 +174,20 @@ SDL.BaseNavigationView = Em.ContainerView.create(
       getResolutionsList: function() {
         return SDL.NavigationController.getVideoStreamingCapabilitiesList();
       }.property(
-        'SDL.NavigationModel.resolutionsList.@each'
+        'SDL.SDLController.model.resolutionsList.@each'
       ),
 
       getResolutionValue: function() {
-        if (SDL.NavigationModel.resolutionIndex < SDL.NavigationModel.resolutionsList.length - 1) {
+        if (SDL.SDLController.model &&
+            SDL.SDLController.model.resolutionIndex < SDL.SDLController.model.resolutionsList.length - 1) {
           return SDL.NavigationController.stringifyCapabilityItem(
-            SDL.NavigationModel.resolutionsList[SDL.NavigationModel.resolutionIndex]
+            SDL.SDLController.model.resolutionsList[SDL.SDLController.model.resolutionIndex]
           );
         }
         return '';
       }.property(
-        'SDL.NavigationModel.resolutionsList.@each',
-        'SDL.NavigationModel.resolutionIndex',
+        'SDL.SDLController.model.resolutionsList.@each',
+        'SDL.SDLController.model.resolutionIndex',
       ),
 
       change: function() {

--- a/ffw/BasicCommunicationRPC.js
+++ b/ffw/BasicCommunicationRPC.js
@@ -440,12 +440,14 @@ FFW.BasicCommunication = FFW.RPCObserver
           if  (capabilities_type == 'VIDEO_STREAMING') {
             const updated_caps = notification.params.appCapability.videoStreamingCapability;
             if (updated_caps.additionalVideoStreamingCapabilities) {
-              if (SDL.NavigationModel.resolutionIndex > updated_caps.additionalVideoStreamingCapabilities.length - 1) {
-                SDL.NavigationModel.set('resolutionIndex',
+              let appModel = SDL.SDLController.getApplicationModel(notification.params.appID);
+
+              if (appModel && appModel.resolutionIndex > updated_caps.additionalVideoStreamingCapabilities.length - 1) {
+                appModel.set('resolutionIndex',
                   updated_caps.additionalVideoStreamingCapabilities.length - 1
                 );
               }
-              SDL.NavigationModel.set('resolutionsList',
+              appModel.set('resolutionsList',
                 updated_caps.additionalVideoStreamingCapabilities
               );
             }


### PR DESCRIPTION
Fixes [#505](https://github.com/smartdevicelink/sdl_hmi/issues/505)

This PR is **ready** for review.

### Testing Plan
Navi app1 is registered and activated,is subscribed to video streaming updates via GetSystemCapability RPC,
app1 has provided supported video capabilities via BC.OnAppCapabilityUpdated,
the drop-down list with resolutions is updated according to values received in BC.OnAppCapabilityUpdated for app1;
then app2 is registered and activated, is visible on screen resolutions(default set) in the drop-down list for newly registered app2.

### Summary
Fixed HMI shows resolutions in the drop-down list not corresponded to app settings in case of multiple apps. Added the possibility to correlate a list of resolutions with the correspond application.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
