### PR TITLE
Send OnAppDeactivated when leaving app screen

### DIFF
--- a/app/controller/sdl/Abstract/Controller.js
+++ b/app/controller/sdl/Abstract/Controller.js
@@ -242,11 +242,11 @@ SDL.SDLController = Em.Object.extend(
      * StateManager
      */
     deactivateApp: function() {
-      SDL.SDLController.onSubMenu('top');
       if (this.model) {
+        SDL.SDLController.onSubMenu('top');
         SDL.SDLModel.onDeactivateApp(SDL.States.nextState, this.model.appID);
+        SDL.SDLController.model.set('tbtActivate', false);
       }
-      SDL.SDLController.model.set('tbtActivate', false);
       this.set('model', null);
     },
     /**

--- a/app/model/sdl/Abstract/Model.js
+++ b/app/model/sdl/Abstract/Model.js
@@ -1748,8 +1748,7 @@ SDL.SDLModel = Em.Object.extend({
       SDL.TurnByTurnView.deactivate();
 
       if (!SDL.SDLModel.data.phoneCallActive &&
-          !SDL.SDLModel.data.templateChangeInProgress &&
-          reason == 'GENERAL') {
+          !SDL.SDLModel.data.templateChangeInProgress) {
         FFW.BasicCommunication.OnAppDeactivated(appID);
       }
     }


### PR DESCRIPTION
Fixes #101 

This PR is **ready** for review.

### Testing Plan
Activate app, open some other view in the HMI. App should be put in `LIMITED` (for media/navigation apps) or `BACKGROUND` (for non-media apps) until it is activated again

### Summary
Send OnAppDeactivated message when changing views in the HMI away from app screen.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
