### PR TITLE
Fix HMI connection to Policy Manager during PTU

### DIFF
--- a/app/controller/SettingsController.js
+++ b/app/controller/SettingsController.js
@@ -377,7 +377,14 @@ SDL.SettingsController = Em.Object.create(
      * @description Runs scheduled PTU iteration if all conditions are met
      */
     runScheduledPtuIteration: function() {
-      if (SDL.SDLModel.data.registeredApps.length > 0 && this.nextPtuIterationScheduled) {
+      let availableForPtuAppExists = false;
+      SDL.SDLModel.data.registeredApps.forEach(app => {
+        if (app.initialized === true) {
+          availableForPtuAppExists = true;
+        }
+      });
+
+      if (availableForPtuAppExists && this.nextPtuIterationScheduled) {
         Em.Logger.log('Starting of PTU iteration');
         this.set('nextPtuIterationScheduled', false);
         if (SDL.SDLModel.data.policyURLs.length > 0) {

--- a/app/controller/SettingsController.js
+++ b/app/controller/SettingsController.js
@@ -377,9 +377,7 @@ SDL.SettingsController = Em.Object.create(
      * @description Observer function to track apps avaliable for PTU
      */
     observeAvailableForPtuApps: function() {
-      if (SDL.SDLModel.data.registeredApps.length > 0) {
-        this.runScheduledPtuIteration();
-      }
+      this.runScheduledPtuIteration();
     }.observes('SDL.SDLModel.data.registeredApps.@each'),
     /**
      * @description Runs scheduled PTU iteration if all conditions are met
@@ -387,6 +385,7 @@ SDL.SettingsController = Em.Object.create(
     runScheduledPtuIteration: function() {
       if (SDL.SDLModel.data.registeredApps.length > 0 && this.nextPtuIterationScheduled) {
         Em.Logger.log('Starting of PTU iteration');
+        this.set('nextPtuIterationScheduled', false);
         if (SDL.SDLModel.data.policyURLs.length > 0) {
           this.OnSystemRequestHandler(SDL.SDLModel.data.policyURLs[0]);
         } else {
@@ -395,7 +394,6 @@ SDL.SettingsController = Em.Object.create(
         if (FLAGS.ExternalPolicies === true) {
           this.policyUpdateRetry();
         }
-        this.set('nextPtuIterationScheduled', false);
       }
     },
     /**

--- a/app/controller/SettingsController.js
+++ b/app/controller/SettingsController.js
@@ -374,12 +374,6 @@ SDL.SettingsController = Em.Object.create(
       this.runScheduledPtuIteration();
     },
     /**
-     * @description Observer function to track apps avaliable for PTU
-     */
-    observeAvailableForPtuApps: function() {
-      this.runScheduledPtuIteration();
-    }.observes('SDL.SDLModel.data.registeredApps.@each'),
-    /**
      * @description Runs scheduled PTU iteration if all conditions are met
      */
     runScheduledPtuIteration: function() {

--- a/app/controller/sdl/Abstract/Controller.js
+++ b/app/controller/sdl/Abstract/Controller.js
@@ -1198,6 +1198,7 @@ SDL.SDLController = Em.Object.extend(
       params.applications.forEach(appRecord => {
         SDL.SDLModel.appIDtoPolicyAppIDMapping[appRecord.appID] = appRecord.policyAppID;
       });
+      SDL.SettingsController.runScheduledPtuIteration();
     },
     /**
      * SDL Driver Distraction ON/OFF switcher

--- a/ffw/BasicCommunicationRPC.js
+++ b/ffw/BasicCommunicationRPC.js
@@ -285,14 +285,7 @@ FFW.BasicCommunication = FFW.RPCObserver
                           if(key == 7) {
                             SDL.SDLModel.data.set('policyURLs', data[key].default);
                             if(!FLAGS.PTUWithModemEnabled) {
-                              if (data[key].default.length) {
-                                SDL.SettingsController.OnSystemRequestHandler(data[key].default[0]);
-                              } else {
-                                SDL.SettingsController.OnSystemRequestHandler();
-                              }
-                              if (FLAGS.ExternalPolicies === true) {
-                                SDL.SettingsController.policyUpdateRetry();
-                              }
+                              SDL.SettingsController.scheduleNextPtuIteration();
                             } else {
                               SDL.SettingsController.requestPTUFromEndpoint(SDL.SettingsController.policyUpdateFile, data[key].default);
                             }

--- a/ffw/ExternalPolicies.js
+++ b/ffw/ExternalPolicies.js
@@ -38,6 +38,10 @@ FFW.ExternalPolicies = Em.Object.create({
 
     waitForUnpackResponse: false,
 
+    packMessagesToSend: [],
+
+    unpackMessagesToSend: [],
+
     sysReqParams: {},
 
     createPackClient(){
@@ -45,10 +49,11 @@ FFW.ExternalPolicies = Em.Object.create({
         var self = this;
         this.packClient.onopen = function(evt) {
             self.onWSOpen(evt, this);
+            self.onPackMessageSend();
         };
         this.packClient.onclose = function(evt) {
             self.onWSClose(evt);
-            this.packClient = null;
+            self.packClient = null;
             setTimeout(() => { self.createPackClient(); }, 5000);
         };
         this.packClient.onmessage = function(evt) {
@@ -64,10 +69,11 @@ FFW.ExternalPolicies = Em.Object.create({
         var self = this;
         this.unpackClient.onopen = function(evt) {
             self.onWSOpen(evt, this);
+            self.onUnpackMessageSend();
         };
         this.unpackClient.onclose = function(evt) {
             self.onWSClose(evt);
-            this.unpackClient = null;
+            self.unpackClient = null;
             setTimeout(() => { self.createUnpackClient(); }, 5000);
         };
         this.unpackClient.onmessage = function(evt) {
@@ -87,6 +93,55 @@ FFW.ExternalPolicies = Em.Object.create({
         Em.Logger.log('ExternalPolicies onWSOpen');
     },
 
+    onWSClose: function(evt) {
+        Em.Logger.log('ExternalPolicies onWSClose');
+    },
+
+    onWSError: function(evt) {
+        Em.Logger.log('ExternalPolicies onWSError');
+    },
+
+    pack: function(params) {
+        Em.Logger.log("Pack")
+        this.sysReqParams = params;
+        this.packMessagesToSend.push(this.sysReqParams);
+        this.onPackMessageSend();
+    },
+
+    onPackMessageSend: function() {
+        if (this.packMessagesToSend.length == 0) {
+            return;
+        }
+
+        const str_message = JSON.stringify(this.packMessagesToSend[0]);
+
+        if (this.packClient && this.packClient.readyState == this.packClient.OPEN){
+            this.packClient.send(str_message);
+            this.packMessagesToSend.pop();
+            this.onPackMessageSend();
+        }
+    },
+
+    unpack: function(params) {
+        Em.Logger.log("Unpack")
+        this.unpackMessagesToSend.push(params);
+        this.onUnpackMessageSend();
+    },
+
+    onUnpackMessageSend: function() {
+        if (this.unpackMessagesToSend.length == 0) {
+            return;
+        }
+
+        const str_message = JSON.stringify(this.unpackMessagesToSend[0]);
+
+        if (this.unpackClient && this.unpackClient.readyState == this.unpackClient.OPEN){
+            this.unpackClient.send(str_message);
+            this.unpackMessagesToSend.pop();
+            this.onUnpackMessageSend();
+        }
+    },
+
     onPackMessage: function(evt) {
         Em.Logger.log('ExternalPolicies onWSMessage ' + evt.data);
         this.packResponseReady = true;
@@ -98,30 +153,13 @@ FFW.ExternalPolicies = Em.Object.create({
         );
 
         this.sysReqParams = {};
-
     },
+
     onUnpackMessage: function(evt) {
         Em.Logger.log('ExternalPolicies onWSMessage ' + evt.data);
         this.unpackResponseReady = true;
 
         FFW.BasicCommunication.OnReceivedPolicyUpdate(evt.data);
     },
-
-    onWSClose: function(evt) {
-        Em.Logger.log('ExternalPolicies onWSClose');
-    },
-    
-    onWSError: function(evt) {
-        Em.Logger.log('ExternalPolicies onWSError');
-    },
-    pack: function(params) {
-        Em.Logger.log("Pack")
-        this.sysReqParams = params;
-        this.packClient.send(JSON.stringify(this.sysReqParams));     
-    },
-    unpack: function(params) {
-        Em.Logger.log("Unpack")
-        this.unpackClient.send(JSON.stringify(params));
-    }
 
 });


### PR DESCRIPTION
Fixes #527

This PR is **ready** for review.

### Testing Plan
Has been tested manually against the following scenario:

1. Activate app and consent device.
=> SDL starts PTU and sends SDL.OnStatusUpdate(UPDATE_NEEDED, UPDATING)
2. Send Ignition Off
3. Start SDL (using `start.sh` script)
=> SDL and Policy Manager are restarted

**Expected result:**
- HMI re-connects to Policy Manager
- Policy Manager is able to handle `BC.OnSystemRequest`

### Summary
There was noticed a timing issue when HMI is not fast enough to connect to Policy Manager backend after ignition off/on. As
SDL starts before the Policy Manager, there might be an issue when SDL continues PTU however HMI is not connected to PM yet which causes an exception and breaks PTU sequence. Also, HMI is trying to perform PTU even if no any apps registered yet which makes no sense if PTU over internal modem is disabled.
The following changes were done:
- Postpone PTU sequence until at least one app is registered
- Resume PTU sequence once app is registered and PTU was postponed
- Postpone sending of messages to Policy Manager until socket is connected
- Resume sending of postponed messages to PM once coonection is established

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
