### PR TITLE
use previous touch coords on cancel event

### DIFF
--- a/app/Flags.js
+++ b/app/Flags.js
@@ -45,6 +45,7 @@ FLAGS = Em.Object.create(
     PYTHON_SERVER_URL: 'ws://127.0.0.1:8081',
     CAN_WEBSOCKET_URL: 'ws://127.0.0.1:2468',
     TOUCH_EVENT_STARTED: false,
+    LAST_TOUCH_POINT: {},
     BasicCommunication: null,
     UI: null,
     VehicleInfo: null,

--- a/app/model/sdl/Abstract/Model.js
+++ b/app/model/sdl/Abstract/Model.js
@@ -188,6 +188,7 @@ SDL.SDLModel = Em.Object.extend({
         events[i].c[0].y = event.originalEvent.changedTouches ?
           event.originalEvent.changedTouches[i].pageY-50 :
           event.originalEvent.pageY-50;
+        FLAGS.LAST_TOUCH_POINT = events[i].c[0];
         events[i].ts = [parseInt(event.timeStamp)];
 
       }

--- a/ffw/UIRPC.js
+++ b/ffw/UIRPC.js
@@ -2082,7 +2082,7 @@ FFW.UI = FFW.RPCObserver.create(
       if (FLAGS.TOUCH_EVENT_STARTED && systemContextValue != 'MAIN'
           && appID == SDL.SDLController.model.appID) {
         FLAGS.TOUCH_EVENT_STARTED = false;
-        FFW.UI.onTouchEvent('CANCEL', [{ id: 0, ts: [parseInt(performance.now())], c: [{ x: 0, y: 0 }] }]);
+        FFW.UI.onTouchEvent('CANCEL', [{ id: 0, ts: [parseInt(performance.now())], c: [FLAGS.LAST_TOUCH_POINT] }]);
       }
 
       // send repsonse


### PR DESCRIPTION
Implements/Fixes https://github.com/smartdevicelink/sdl_hmi/issues/548

This PR is **ready** for review.

### Testing Plan
Cancel a touch event and check coordinates

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
