### PR TITLE
Fix media indicator icons

### DIFF
--- a/app/view/media/sdl/controllsView.js
+++ b/app/view/media/sdl/controllsView.js
@@ -83,18 +83,15 @@ SDL.SDLMediaControlls = Em.ContainerView.create(
               'prevcd'
             ],
             onIconChange: function() {
-              let icon = "images/media/ico_prew.png"; 
-              for (var i = 0; i < SDL.SDLModel.data.registeredApps.length; i++) {
-                if (SDL.SDLMediaController.currentAppId
-                  == SDL.SDLModel.data.registeredApps[i].appID) { 
-                  icon = (SDL.SDLModel.data.registeredApps[i].backSeekIndicator?.type === 'TIME')
-                    ? "images/media/ico_seek_left.png" : icon;                  
-                  break;
-                }
+              let icon = "images/media/ico_prew.png";
+              if (SDL.SDLController.model && SDL.SDLController.model.backSeekIndicator) {
+                icon = (SDL.SDLController.model.backSeekIndicator?.type === 'TIME')
+                    ? "images/media/ico_seek_left.png"
+                    : icon;
               }
               return icon;
             }.property(
-              'SDL.SDLModel.data.registeredApps.@each.backSeekIndicator'
+              'SDL.SDLController.model.backSeekIndicator'
             ),
             iconBinding: 'onIconChange',
             presetName: 'SEEKLEFT'
@@ -144,18 +141,15 @@ SDL.SDLMediaControlls = Em.ContainerView.create(
             ],
             classNameBindings: 'SDL.SDLController.model.SEEKRIGHT::unsubscribed',
             onIconChange: function() {
-              let icon = "images/media/ico_next.png"; 
-              for (var i = 0; i < SDL.SDLModel.data.registeredApps.length; i++) {
-                if (SDL.SDLMediaController.currentAppId
-                  == SDL.SDLModel.data.registeredApps[i].appID) { 
-                  icon = (SDL.SDLModel.data.registeredApps[i].forwardSeekIndicator?.type === 'TIME')
-                    ? "images/media/ico_seek_right.png" : icon;                  
-                  break;
-                }
+              let icon = "images/media/ico_next.png";
+              if (SDL.SDLController.model && SDL.SDLController.model.forwardSeekIndicator) {
+                icon = (SDL.SDLController.model.forwardSeekIndicator?.type === 'TIME')
+                    ? "images/media/ico_seek_right.png"
+                    : icon;
               }
               return icon;
             }.property(
-              'SDL.SDLModel.data.registeredApps.@each.forwardSeekIndicator'
+              'SDL.SDLController.model.forwardSeekIndicator'
             ),
             iconBinding: 'onIconChange',
             presetName: 'SEEKRIGHT'


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_hmi/issues/519

This PR is **ready** for review.

### Testing Plan
**Precondition:**
1. SDL and HMI are started
2. App1 and App2 with HMI type 'Media' are registered
3. App1 is activated
4. App1 sends SetMediaClockTimer RPC with:
"updateMode":"COUNTUP",
"startTime": { "hours":0, "minutes":15, "seconds":30 },
"backSeekIndicator": {"seekTime":30,"type":"TIME" },
"forwardSeekIndicator": { "seekTime":30,"type":"TIME"}
5. The seek indicators are "TIME" for App1
'SEEKLEFT' button with "ico_seek_left.png" image is observed on HMI
'SEEKRIGHT' button with "ico_seek_right.png" image is observed on HMI

**Steps to reproduce:**
1. Activate App2

**Expected result:**
1. App2 is activated successfully
2. By default the seek indicators are "TRACK":
  SEEKLEFT' button with "ico_prew.png" image is observed on HMI for App2
  'SEEKRIGHT' button with "Ico_next.png" image is observed on HMI for App2

### Summary
The issues is observed while working with multiple media applications registered. Once media indicators are changed for one application, second application shows also changed indicators instead of their own.
To resolve that, propery binding was changed to active model which triggers callbacks properly and allows to display the correct seek indicators for each media application.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
