### PR TITLE
Fix/fix resolution index after editor changes

### DIFF
--- a/app/controller/SettingsController.js
+++ b/app/controller/SettingsController.js
@@ -752,6 +752,15 @@ SDL.SettingsController = Em.Object.create(
         if (new_data != old_data) {
           SDL.systemCapabilities.set('videoStreamingCapability', data);
           if (SDL.States.nextState != SDL.States.settings.policies.get('path')) {
+            const preffered = SDL.NavigationController.stringifyCapabilityItem(data);
+            const preset_list = SDL.NavigationController.getVideoStreamingCapabilitiesList();
+            const index = preset_list.indexOf(preffered);
+
+            if (index >= 0) {
+              Em.Logger.log(`Switching video streaming preset to: ${preffered}`);
+              SDL.NavigationController.model.set('resolutionIndex', index);
+            }
+
             that.sendVideoStreamingCapabilities();
           }
         }

--- a/ffw/NavigationRPC.js
+++ b/ffw/NavigationRPC.js
@@ -325,6 +325,20 @@ FFW.Navigation = FFW.RPCObserver.create(
                 appConfig: request.params.config,
                 webmSupport: can_play
               };
+
+              const preffered = SDL.NavigationController.stringifyCapabilityItem({
+                preferredResolution: {
+                  resolutionWidth:  request.params.config.width,
+                  resolutionHeight: request.params.config.height
+                }
+              });
+              const preset_list = SDL.NavigationController.getVideoStreamingCapabilitiesList();
+              const index = preset_list.indexOf(preffered);
+
+              if (index >= 0) {
+                Em.Logger.log(`Switching video streaming preset to: ${preffered}`);
+                SDL.NavigationController.model.set('resolutionIndex', index);
+              }
             }
 
             this.sendNavigationResult(


### PR DESCRIPTION
Fixes #547 

This PR is **ready** for review.

### Testing Plan
**Precondition:**
- HMI and SDL are started
- Navigation mobile app is registered

**Steps to reproduce:**
- Mobile app starts video streaming
- Go to HMI main menu
- Menu item Send VIDEO_STREAMING capabilities
- Update video capabilities to any preferred resolution values (for example "resolutionWidth": 320, "resolutionHeight": 200)
- Press Send notification
Note: HMI shows video with the wrong resolution also in case when the mobile app starts stream with the resolution different from the default(800*480)

**Expected behavior:**
- Mobile app starts streaming with the new resolution 320x200
- HMI shows streaming with new resolution 320x200

### Summary
Looks like video streaming resolution combobox is not affected by settings changed in code editor. This PR provides changes related to proper calculation of video streaming resolution index once user applies custom settings.
Also, as an extra step for a proper resolution switching, the same logic has been added for `SetVideoConfig` to prevent case when application start streaming video in the resolution which is not the same as shown on the combobox


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
