### PR TITLE
Find correct preferred resolution with scale

### DIFF
--- a/ffw/NavigationRPC.js
+++ b/ffw/NavigationRPC.js
@@ -339,7 +339,7 @@ FFW.Navigation = FFW.RPCObserver.create(
                 Em.Logger.log("App Preferred Index: " + index)
                 if (index >= 0 && index !== app_model.resolutionIndex) {
                   Em.Logger.log(`Switching video streaming preset to: ${preferred}`);
-                  SDL.NavigationController.model.set('resolutionIndex', index);
+app_model.set('resolutionIndex', index);
                 } else if (index < 0) {
                   Em.Logger.log("Could not find resolution: " + preferred);
                 } else {

--- a/ffw/NavigationRPC.js
+++ b/ffw/NavigationRPC.js
@@ -339,7 +339,7 @@ FFW.Navigation = FFW.RPCObserver.create(
                 Em.Logger.log("App Preferred Index: " + index)
                 if (index >= 0 && index !== app_model.resolutionIndex) {
                   Em.Logger.log(`Switching video streaming preset to: ${preferred}`);
-app_model.set('resolutionIndex', index);
+                  app_model.set('resolutionIndex', index);
                 } else if (index < 0) {
                   Em.Logger.log("Could not find resolution: " + preferred);
                 } else {

--- a/ffw/NavigationRPC.js
+++ b/ffw/NavigationRPC.js
@@ -326,18 +326,33 @@ FFW.Navigation = FFW.RPCObserver.create(
                 webmSupport: can_play
               };
 
-              const preffered = SDL.NavigationController.stringifyCapabilityItem({
-                preferredResolution: {
-                  resolutionWidth:  request.params.config.width,
-                  resolutionHeight: request.params.config.height
+              const set_preferred = function(width, height, scale) {
+                const preferred = SDL.NavigationController.stringifyCapabilityItem({
+                  preferredResolution: {
+                    resolutionWidth:  width,
+                    resolutionHeight: height
+                  },
+                  scale: scale
+                });
+                const preset_list = SDL.NavigationController.getVideoStreamingCapabilitiesList();
+                const index = preset_list.indexOf(preferred);
+                Em.Logger.log("App Preferred Index: " + index)
+                if (index >= 0 && index !== app_model.resolutionIndex) {
+                  Em.Logger.log(`Switching video streaming preset to: ${preferred}`);
+                  SDL.NavigationController.model.set('resolutionIndex', index);
+                } else if (index < 0) {
+                  Em.Logger.log("Could not find resolution: " + preferred);
+                } else {
+                  Em.Logger.log("Already using resolution: " + preferred);
                 }
-              });
-              const preset_list = SDL.NavigationController.getVideoStreamingCapabilitiesList();
-              const index = preset_list.indexOf(preffered);
-
-              if (index >= 0) {
-                Em.Logger.log(`Switching video streaming preset to: ${preffered}`);
-                SDL.NavigationController.model.set('resolutionIndex', index);
+                return index;  
+              }
+              // Scale is not included in setVideoConfig request, use last set scale.
+              const scale = app_model.resolutionsList[app_model.resolutionIndex].scale;
+              var index = set_preferred(request.params.config.width, request.params.config.height, scale);
+              if (index < 0) {
+                // Find preferred without scale in name
+                set_preferred(request.params.config.width, request.params.config.height, undefined);
               }
             }
 


### PR DESCRIPTION
Implements/Fixes #547 

This PR is **ready** for review.

### Testing Plan
App starts stream with non-default/preferred resolution.

### Summary
The resolutions in the sdl hmi use the scale parameter in their name, so this effects the changes included in #552 where the scaling parameter does not exist in the setVideoConfig request. HMI will make an attempt to find the resolution with the last set scale, or find the resolution that does not include a scaling parameter.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
