### PR TITLE
Fix `seatControlData.memory.id` type in OnInteriorVD notification

### DIFF
--- a/app/model/SeatModel.js
+++ b/app/model/SeatModel.js
@@ -203,6 +203,8 @@ SDL.SeatModel = Em.Object.extend({
             parseInt(this.tempSeatControlData.headSupportHorizontalPosition);
         this.tempSeatControlData.headSupportVerticalPosition =
             parseInt(this.tempSeatControlData.headSupportVerticalPosition);
+        this.tempSeatControlData.memory.id = 
+            parseInt(this.tempSeatControlData.memory.id);
 
         this.set('tempSeatControlData',
             SDL.deepCopy(this.tempSeatControlData));
@@ -237,7 +239,7 @@ SDL.SeatModel = Em.Object.extend({
 
         this.tempSeatControlData.memory = this.seatMemoryAction;
         this.set('seatControlData', SDL.deepCopy(this.tempSeatControlData));
-        var memorySlot = "1";
+        var memorySlot = 1;
         this.memory[memorySlot] = SDL.deepCopy(this.tempSeatControlData);
         this.createdMemory = memorySlot;
     },
@@ -356,10 +358,11 @@ SDL.SeatModel = Em.Object.extend({
      */
     applyMemory: function() {
         var action = this.tempSeatControlData.memory.action;
+        this.tempSeatControlData.memory.id = parseInt(this.tempSeatControlData.memory.id);
 
         switch(action){
             case 'SAVE':
-                if(this.tempSeatControlData.memory.id>0 &
+                if(this.tempSeatControlData.memory.id>0 &&
                     this.tempSeatControlData.memory.id<=10){
                         
                         var id = this.tempSeatControlData.memory.id;


### PR DESCRIPTION


Implements/Fixes #554

This PR is **ready** for review.

### Testing Plan
Edit the `memory` data field in the seat data view along with several other fields. Press the "Set" button and verify that all subscribed apps receive an `OnInteriorVehicleData(SEAT)` notification

### Summary
Core was marking the HMI's OnInteriorVehicleData invalid because `seatControlData.memory.id` was sent as a string, preventing the app from receiving the notification. This fixes the logic so an integer is sent instead

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
