### PR TITLE
Make correct resolution switching

### DIFF
--- a/app/controller/SettingsController.js
+++ b/app/controller/SettingsController.js
@@ -784,20 +784,22 @@ SDL.SettingsController = Em.Object.create(
 
       let that = this;
       SDL.SendVideoStreamingCapsView.videoCapabilitiesCodeEditor.activate(function(data) {
+        // Trigger 'change' event to force overwriting 'selection' field 
+        // with current value of selected appID. Otherwise it will be null.
+        SDL.SendVideoStreamingCapsView.appIDContainerView.appIDSelect.trigger('change');
+
         const new_data = JSON.stringify(data);
         const old_data = JSON.stringify(SDL.systemCapabilities.videoStreamingCapability);
+        SDL.NavigationController.setPreferredResolutionIndex(
+          parseInt(SDL.SendVideoStreamingCapsView.appIDContainerView.appIDSelect.selection),
+          data.preferredResolution.resolutionWidth,
+          data.preferredResolution.resolutionHeight,
+          data.scale
+        );
+
         if (new_data != old_data) {
           SDL.systemCapabilities.set('videoStreamingCapability', data);
           if (SDL.States.nextState != SDL.States.settings.policies.get('path')) {
-            const preffered = SDL.NavigationController.stringifyCapabilityItem(data);
-            const preset_list = SDL.NavigationController.getVideoStreamingCapabilitiesList();
-            const index = preset_list.indexOf(preffered);
-
-            if (index >= 0) {
-              Em.Logger.log(`Switching video streaming preset to: ${preffered}`);
-              SDL.NavigationController.model.set('resolutionIndex', index);
-            }
-
             that.sendVideoStreamingCapabilities();
           }
         }

--- a/app/view/navigationApp/baseNavigationView.js
+++ b/app/view/navigationApp/baseNavigationView.js
@@ -172,7 +172,7 @@ SDL.BaseNavigationView = Em.ContainerView.create(
       valueBinding: 'getResolutionValue',
 
       getResolutionsList: function() {
-        return SDL.NavigationController.getVideoStreamingCapabilitiesList();
+        return SDL.NavigationController.getVideoStreamingCapabilitiesList(SDL.SDLController.model);
       }.property(
         'SDL.SDLController.model.resolutionsList.@each'
       ),

--- a/ffw/NavigationRPC.js
+++ b/ffw/NavigationRPC.js
@@ -325,36 +325,13 @@ FFW.Navigation = FFW.RPCObserver.create(
                 appConfig: request.params.config,
                 webmSupport: can_play
               };
-
-              const set_preferred = function(width, height, scale) {
-                const preferred = SDL.NavigationController.stringifyCapabilityItem({
-                  preferredResolution: {
-                    resolutionWidth:  width,
-                    resolutionHeight: height
-                  },
-                  scale: scale
-                });
-                const preset_list = SDL.NavigationController.getVideoStreamingCapabilitiesList();
-                const index = preset_list.indexOf(preferred);
-                Em.Logger.log("App Preferred Index: " + index)
-                if (index >= 0 && index !== app_model.resolutionIndex) {
-                  Em.Logger.log(`Switching video streaming preset to: ${preferred}`);
-                  app_model.set('resolutionIndex', index);
-                } else if (index < 0) {
-                  Em.Logger.log("Could not find resolution: " + preferred);
-                } else {
-                  Em.Logger.log("Already using resolution: " + preferred);
-                }
-                return index;  
-              }
-              // Scale is not included in setVideoConfig request, use last set scale.
-              const scale = app_model.resolutionsList[app_model.resolutionIndex].scale;
-              var index = set_preferred(request.params.config.width, request.params.config.height, scale);
-              if (index < 0) {
-                // Find preferred without scale in name
-                set_preferred(request.params.config.width, request.params.config.height, undefined);
-              }
             }
+
+            SDL.NavigationController.setPreferredResolutionIndex(
+              request.params.appID,
+              request.params.config.width,
+              request.params.config.height
+            );
 
             this.sendNavigationResult(
               SDL.SDLModel.data.resultCode.SUCCESS,


### PR DESCRIPTION
Make correct resolution switching for both editor and SetVideoConfig

Fixes #547 

This PR is **ready** for review.

### Testing Plan
App starts stream with non-default/preferred resolution.

### Summary
The resolutions in the sdl hmi use the scale parameter in their name, so this effects the changes included in #552 where the scaling parameter does not exist in the setVideoConfig request. HMI will make an attempt to find the resolution with the last set scale, or find the resolution that does not include a scaling parameter.
This PR extends logic of #553 making it applicable for both editor and SetVideoConfig request.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
