### PR TITLE
Include additional resolutions in OSCU

### DIFF
--- a/app/controller/NavigationController.js
+++ b/app/controller/NavigationController.js
@@ -506,6 +506,9 @@ SDL.NavigationController = Em.Object.create(
           capabilities_to_send.scale = capability_to_switch.scale;
         }
 
+        capabilities_to_send.additionalVideoStreamingCapabilities = 
+          SDL.SDLController.model.resolutionsList;
+
         const json_to_send = {
           'systemCapability' : {
             'systemCapabilityType': 'VIDEO_STREAMING',


### PR DESCRIPTION
This PR is **ready** for review.

### Testing Plan
Activate app
Switch resolution to  480x320 via dropdown
Start stream on app
After stream starts Try to switch resolutions again, all resolutions should still be in the list.

### Summary
This is a change to prevent some undesired behavior seen with the mobile libraries of handling the OSCU notification before the stream starts. OSCU seems to overwrite the entire resolution list for the app since the app will only send back the new switched preferred resolution instead of the whole list.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
