### PR TITLE
Don't send GetUserFriendlyMessage when app does not have specific permissions

### DIFF
--- a/app/controller/SettingsController.js
+++ b/app/controller/SettingsController.js
@@ -219,10 +219,12 @@ SDL.SettingsController = Em.Object.create(
         for (var i = 0; i < message.result.allowedFunctions.length; i++) {
           messageCodes.push(message.result.allowedFunctions[i].name);
         }
-        FFW.BasicCommunication.GetUserFriendlyMessage(
-          SDL.SettingsController.permissionsFriendlyMessageUpdate, appID,
-          messageCodes
-        );
+        if (messageCodes.length > 0) {
+          FFW.BasicCommunication.GetUserFriendlyMessage(
+            SDL.SettingsController.permissionsFriendlyMessageUpdate, appID,
+            messageCodes
+          );
+        }
         SDL.AppPermissionsView.update(message.result.allowedFunctions, appID);
         delete SDL.SDLModel.data.getListOfPermissionsPull[message.id];
       }


### PR DESCRIPTION

Fixes #558

This PR is **ready** for review.

### Testing Plan
In EXTERNAL policy mode, open the app permissions view for an app with default permissions

### Summary
Don't send GetUserFriendlyMessage when an app does not have specific permissions

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
