### PR TITLE
Fix/Only send OnReceivedPolicyUpdate for request type PROPRIETARY

### DIFF
--- a/ffw/BasicCommunicationRPC.js
+++ b/ffw/BasicCommunicationRPC.js
@@ -602,7 +602,9 @@ FFW.BasicCommunication = FFW.RPCObserver
                 fileName: request.params.fileName
               });
             } else {
-              this.OnReceivedPolicyUpdate(request.params.fileName);
+              if (request.params.requestType == 'PROPRIETARY') {
+                this.OnReceivedPolicyUpdate(request.params.fileName);
+              }
             }
 
             if (request.params.requestType == 'OEM_SPECIFIC' &&

--- a/ffw/ExternalPolicies.js
+++ b/ffw/ExternalPolicies.js
@@ -159,7 +159,18 @@ FFW.ExternalPolicies = Em.Object.create({
         Em.Logger.log('ExternalPolicies onWSMessage ' + evt.data);
         this.unpackResponseReady = true;
 
-        FFW.BasicCommunication.OnReceivedPolicyUpdate(evt.data);
+        let jsonData;
+        try {
+            jsonData = JSON.parse(evt.data)
+        }
+        catch {
+            Em.Logger.log('ExternalPolicies: failed to parse JSON content from WSMessage');
+            return;
+        }
+
+        if(jsonData.requestType == 'PROPRIETARY'){
+            FFW.BasicCommunication.OnReceivedPolicyUpdate(jsonData.data);
+        }
     },
 
 });


### PR DESCRIPTION
Implements/Fixes #560

This PR is **ready** for review.

### Testing Plan
Run the following steps for both PROPRIETARY and EXTERNAL_PROPRIETARY

1. Send SystemRequest {requestType: "CLIMATE", fileName: "climateData.json"} from the mobile app 
2. Confirm that HMI does NOT send `SDL.OnReceivedPolicyUpdate` with "climateData.json"

Core branch: https://github.com/smartdevicelink/sdl_core/tree/fix/return_requestype_in_sample_policy_manager_response

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
