### PR TITLE
Populate all fields for additional streaming capabilities

### DIFF
--- a/app/controller/NavigationController.js
+++ b/app/controller/NavigationController.js
@@ -491,23 +491,11 @@ SDL.NavigationController = Em.Object.create(
       if (index >= 0) {
         Em.Logger.log(`Switching video streaming preset to: ${preset_name}`);
         SDL.SDLController.model.set('resolutionIndex', index);
-        const capability_to_switch = SDL.SDLController.model.resolutionsList[index];
-        let capabilities_to_send = {};
-
-        if (capability_to_switch.preferredResolution) {
-          capabilities_to_send.preferredResolution = {};
-          capabilities_to_send.preferredResolution.resolutionWidth =
-            capability_to_switch.preferredResolution.resolutionWidth;
-          capabilities_to_send.preferredResolution.resolutionHeight =
-            capability_to_switch.preferredResolution.resolutionHeight;
-        }
-
-        if (capability_to_switch.scale) {
-          capabilities_to_send.scale = capability_to_switch.scale;
-        }
-
-        capabilities_to_send.additionalVideoStreamingCapabilities = 
-          SDL.SDLController.model.resolutionsList;
+        let capabilities_to_send  = JSON.parse(JSON.stringify(SDL.SDLController.model.resolutionsList[index]));
+        let resolutions_list = JSON.parse(JSON.stringify(SDL.SDLController.model.resolutionsList));
+        // Remove new selected resolution from the additional capabilities
+        resolutions_list.splice(index, 1);
+        capabilities_to_send.additionalVideoStreamingCapabilities = resolutions_list;
 
         const json_to_send = {
           'systemCapability' : {

--- a/app/model/sdl/Abstract/AppModel.js
+++ b/app/model/sdl/Abstract/AppModel.js
@@ -546,9 +546,10 @@ SDL.ABSAppModel = Em.Object.extend(
 
       this.set('maskInputCharactersUserChoice', true);
 
-      this.set('resolutionsList',
-        SDL.systemCapabilities.videoStreamingCapability.additionalVideoStreamingCapabilities
-      );
+      var all_resolutions = [JSON.parse(JSON.stringify(SDL.systemCapabilities.videoStreamingCapability))];
+      delete all_resolutions[0].additionalVideoStreamingCapabilities;
+      all_resolutions = all_resolutions.concat(SDL.systemCapabilities.videoStreamingCapability.additionalVideoStreamingCapabilities);
+      this.set('resolutionsList', all_resolutions);
     },
     /**
      * @description Gets app default keyboard global properties

--- a/capabilities/systemCapabilities.js
+++ b/capabilities/systemCapabilities.js
@@ -47,18 +47,6 @@ SDL.systemCapabilities = Em.Object.create(
             {
                 protocol:  "RTP",
                 codec: "H264"
-            },
-            {
-                protocol:  "RTSP",
-                codec: "Theora"
-            },
-            {
-                protocol:  "RTMP",
-                codec: "VP8"
-            },
-            {
-                protocol:  "WEBM",
-                codec: "VP9"
             }
         ],
         hapticSpatialDataSupported: true,
@@ -70,21 +58,25 @@ SDL.systemCapabilities = Em.Object.create(
             {
                 preferredResolution:
                 {
-                    resolutionWidth: 800,
-                    resolutionHeight: 380
-                },
-                hapticSpatialDataSupported: true,
-                scale: 1,
-                diagonalScreenSize: 8
-            },
-            {
-                preferredResolution:
-                {
                     resolutionWidth: 320,
                     resolutionHeight: 200
                 },
+                maxBitrate: 400000,
                 hapticSpatialDataSupported: false,
-                diagonalScreenSize: 3
+                diagonalScreenSize: 3,
+                pixelPerInch: 96,
+                scale: 1,
+                preferredFPS: 20,
+                supportedFormats: [
+                    {
+                        protocol:  "RAW",
+                        codec: "H264"
+                    },
+                    {
+                        protocol:  "RTP",
+                        codec: "H264"
+                    }
+                ]
             },
             {
                 preferredResolution:
@@ -92,8 +84,22 @@ SDL.systemCapabilities = Em.Object.create(
                     resolutionWidth: 480,
                     resolutionHeight: 320
                 },
+                maxBitrate: 400000,
                 hapticSpatialDataSupported: true,
-                diagonalScreenSize: 5
+                diagonalScreenSize: 5,
+                pixelPerInch: 96,
+                scale: 1,
+                preferredFPS: 20,
+                supportedFormats: [
+                    {
+                        protocol:  "RAW",
+                        codec: "H264"
+                    },
+                    {
+                        protocol:  "RTP",
+                        codec: "H264"
+                    }
+                ]
             },
             {
                 preferredResolution:
@@ -101,8 +107,22 @@ SDL.systemCapabilities = Em.Object.create(
                     resolutionWidth: 400,
                     resolutionHeight: 380
                 },
+                maxBitrate: 400000,
                 hapticSpatialDataSupported: true,
-                diagonalScreenSize: 4
+                diagonalScreenSize: 4,
+                pixelPerInch: 96,
+                scale: 1,
+                preferredFPS: 20,
+                supportedFormats: [
+                    {
+                        protocol:  "RAW",
+                        codec: "H264"
+                    },
+                    {
+                        protocol:  "RTP",
+                        codec: "H264"
+                    }
+                ]
             },
             {
                 preferredResolution:
@@ -110,8 +130,22 @@ SDL.systemCapabilities = Em.Object.create(
                     resolutionWidth: 800,
                     resolutionHeight: 240
                 },
+                maxBitrate: 400000,
                 hapticSpatialDataSupported: true,
-                diagonalScreenSize: 4
+                diagonalScreenSize: 4,
+                pixelPerInch: 96,
+                scale: 1,
+                preferredFPS: 20,
+                supportedFormats: [
+                    {
+                        protocol:  "RAW",
+                        codec: "H264"
+                    },
+                    {
+                        protocol:  "RTP",
+                        codec: "H264"
+                    }
+                ]
             },
             {
                 preferredResolution:
@@ -119,9 +153,22 @@ SDL.systemCapabilities = Em.Object.create(
                     resolutionWidth: 800,
                     resolutionHeight: 380
                 },
+                maxBitrate: 400000,
                 hapticSpatialDataSupported: true,
                 scale: 1.5,
-                diagonalScreenSize: 5
+                diagonalScreenSize: 5,
+                pixelPerInch: 96,
+                preferredFPS: 20,
+                supportedFormats: [
+                    {
+                        protocol:  "RAW",
+                        codec: "H264"
+                    },
+                    {
+                        protocol:  "RTP",
+                        codec: "H264"
+                    }
+                ]
             },
             {
                 preferredResolution:
@@ -129,9 +176,22 @@ SDL.systemCapabilities = Em.Object.create(
                     resolutionWidth: 800,
                     resolutionHeight: 380
                 },
+                maxBitrate: 400000,
                 hapticSpatialDataSupported: true,
                 scale: 2,
-                diagonalScreenSize: 4
+                diagonalScreenSize: 4,
+                pixelPerInch: 96,
+                preferredFPS: 20,
+                supportedFormats: [
+                    {
+                        protocol:  "RAW",
+                        codec: "H264"
+                    },
+                    {
+                        protocol:  "RTP",
+                        codec: "H264"
+                    }
+                ]
             }
         ]
     },

--- a/capabilities/systemCapabilities.js
+++ b/capabilities/systemCapabilities.js
@@ -47,6 +47,10 @@ SDL.systemCapabilities = Em.Object.create(
             {
                 protocol:  "RTP",
                 codec: "H264"
+            },
+            {
+                protocol:  "WEBM",
+                codec: "VP8"
             }
         ],
         hapticSpatialDataSupported: true,
@@ -75,6 +79,10 @@ SDL.systemCapabilities = Em.Object.create(
                     {
                         protocol:  "RTP",
                         codec: "H264"
+                    },
+                    {
+                        protocol:  "WEBM",
+                        codec: "VP8"
                     }
                 ]
             },
@@ -98,6 +106,10 @@ SDL.systemCapabilities = Em.Object.create(
                     {
                         protocol:  "RTP",
                         codec: "H264"
+                    },
+                    {
+                        protocol:  "WEBM",
+                        codec: "VP8"
                     }
                 ]
             },
@@ -121,6 +133,10 @@ SDL.systemCapabilities = Em.Object.create(
                     {
                         protocol:  "RTP",
                         codec: "H264"
+                    },
+                    {
+                        protocol:  "WEBM",
+                        codec: "VP8"
                     }
                 ]
             },
@@ -144,6 +160,10 @@ SDL.systemCapabilities = Em.Object.create(
                     {
                         protocol:  "RTP",
                         codec: "H264"
+                    },
+                    {
+                        protocol:  "WEBM",
+                        codec: "VP8"
                     }
                 ]
             },
@@ -167,6 +187,10 @@ SDL.systemCapabilities = Em.Object.create(
                     {
                         protocol:  "RTP",
                         codec: "H264"
+                    },
+                    {
+                        protocol:  "WEBM",
+                        codec: "VP8"
                     }
                 ]
             },
@@ -190,6 +214,10 @@ SDL.systemCapabilities = Em.Object.create(
                     {
                         protocol:  "RTP",
                         codec: "H264"
+                    },
+                    {
+                        protocol:  "WEBM",
+                        codec: "VP8"
                     }
                 ]
             }

--- a/ffw/BasicCommunicationRPC.js
+++ b/ffw/BasicCommunicationRPC.js
@@ -434,12 +434,24 @@ FFW.BasicCommunication = FFW.RPCObserver
             const updated_caps = notification.params.appCapability.videoStreamingCapability;
             if (updated_caps.additionalVideoStreamingCapabilities) {
               let appModel = SDL.SDLController.getApplicationModel(notification.params.appID);
-
-              if (appModel && appModel.resolutionIndex > updated_caps.additionalVideoStreamingCapabilities.length - 1) {
-                appModel.set('resolutionIndex',
-                  updated_caps.additionalVideoStreamingCapabilities.length - 1
-                );
+              if (appModel) {
+                // Order of capabilities is not guaranteed. Find resolution index.
+                var current_res = SDL.NavigationController.stringifyCapabilityItem(appModel.resolutionsList[appModel.resolutionIndex]);
+                var i=0;
+                for (; i<updated_caps.additionalVideoStreamingCapabilities.length; i++) {
+                  const comp_res = SDL.NavigationController.stringifyCapabilityItem(updated_caps.additionalVideoStreamingCapabilities[i])
+                  if (current_res === comp_res) {
+                    appModel.set('resolutionIndex', i)
+                    break;
+                  }
+                }
+                if (i == updated_caps.additionalVideoStreamingCapabilities.length) {
+                  appModel.set('resolutionIndex',
+                    updated_caps.additionalVideoStreamingCapabilities.length - 1
+                  );
+                }
               }
+              
               appModel.set('resolutionsList',
                 updated_caps.additionalVideoStreamingCapabilities
               );


### PR DESCRIPTION
Fixes: #563 

This PR is **ready** for review.

### Testing Plan
Test switching between resolutions using java suite and ios applications.

### Summary

Mobile libraries have an issue with the additional capabilities being sent during resolution switches. The additional capability fields dont include important parameters like bitrate, perferredFps, pixelPerInch, etc. These parameters are used to create identifiers for each capability in the mobile library.

The HMI technically isnt doing anything wrong according to the spec, this change is just to alleviate some issues seen in the mobile releases for the video switching feature.

SDL HMI should update the additional fields to include all information in each capability object.

Documentation should also be updated to include how SystemCapability and OSCU notification should be formatted by the HMI.

Changes:

- Remove 800x380 duplicate resolution and fix issues caused by removing duplicated resolution.
- Include bitrate, ppi, scale, etc in every capability object
- Remove inaccurate supported streaming formats

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
