### PR TITLE
Use normal response format when sending sliderPosition

### DIFF
--- a/ffw/UIRPC.js
+++ b/ffw/UIRPC.js
@@ -1916,8 +1916,7 @@ FFW.UI = FFW.RPCObserver.create(
      */
     sendSliderResult: function(resultCode, sliderRequestID, sliderPosition) {
       Em.Logger.log('FFW.UI.SliderResponse');
-      if (resultCode === SDL.SDLModel.data.resultCode.SUCCESS) {
-
+      if (resultCode === SDL.SDLModel.data.resultCode.SUCCESS || sliderPosition) {
         // send repsonse
         var JSONMessage = {
           'jsonrpc': '2.0',
@@ -1937,15 +1936,12 @@ FFW.UI = FFW.RPCObserver.create(
           'id': sliderRequestID,
           'error': {
             'code': resultCode, // type (enum) from SDL protocol
-            'message': 'Slider request ABORTED or TIMED OUT.',
+            'message': 'Slider request failed.',
             'data': {
               'method': 'UI.Slider'
             }
           }
         };
-        if (sliderPosition) {
-          JSONMessage.error.data.sliderPosition = sliderPosition;
-        }
       }
       this.sendMessage(JSONMessage);
     },


### PR DESCRIPTION
Implements/Fixes https://github.com/smartdevicelink/sdl_core/issues/3676

This PR is **ready** for review.

### Testing Plan
Manual testing against SDL Core PR (https://github.com/smartdevicelink/sdl_core/pull/3697), app should receive sliderPosition in ABORTED or TIMED_OUT response for Slider.

### Summary
When sending a Slider response, use error format only if sliderPosition is not provided, otherwise this parameter will be cut off by SDL Core

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
