### PR TITLE
Fix closeButton formatting for AlertManeuver

### DIFF
--- a/app/view/sdl/AlertManeuverPopUp.js
+++ b/app/view/sdl/AlertManeuverPopUp.js
@@ -45,8 +45,7 @@ SDL.AlertManeuverPopUp = Em.ContainerView.create(
       // 'message1',
       // 'message2',
       // 'message3',
-      'softbuttons',
-      'closeButton'
+      'softbuttons'
     ],
     content1: 'Title',
     content2: 'Text',
@@ -55,7 +54,6 @@ SDL.AlertManeuverPopUp = Em.ContainerView.create(
     timer: null,
     timeout: 5000,
     alertManeuerRequestId: 0,
-    isCloseButtonVisible: true,
     /**
      * @desc Defines whether icons paths verified successfully.
      */
@@ -143,7 +141,6 @@ SDL.AlertManeuverPopUp = Em.ContainerView.create(
           var button = items[i];
           button.setMode(SDL.SDLModel.data.imageMode);
       }
-      this.closeButton.setMode(SDL.SDLModel.data.imageMode);
     }.observes('SDL.SDLModel.data.imageMode'),
 
     /**
@@ -152,7 +149,8 @@ SDL.AlertManeuverPopUp = Em.ContainerView.create(
      */
     addSoftButtons: function(params) {
       const softButtons = params.softButtons;
-      if (!softButtons) {
+      if (!softButtons || softButtons.length == 0) {
+        this.get('softbuttons.buttons.childViews').pushObject(this.closeButton);
         return;
       }
 
@@ -225,10 +223,6 @@ SDL.AlertManeuverPopUp = Em.ContainerView.create(
       }
 
       SDL.SDLModel.validateImages(this.alertManeuerRequestId, callback, imageList);
-
-      if (softButtons.length > 0) {
-        this.set('isCloseButtonVisible', false);
-      }
     },
     /**
      * Deactivate PopUp
@@ -259,7 +253,6 @@ SDL.AlertManeuverPopUp = Em.ContainerView.create(
 
       this.set('iconsAreValid', true);
       this.set('infoMessage', null);
-      this.set('isCloseButtonVisible', true);
       this.set('alertManeuerRequestId', message.id);
       this.addSoftButtons(message.params);
 

--- a/css/sdl.css
+++ b/css/sdl.css
@@ -1574,9 +1574,9 @@
 
 
 #AlertManeuverPopUp .closeButton {
-    width: 170px;
-    top: 180px;
-    left: 110px;
+    width: 230px;
+    top: 85px;
+    left: 80px;
 }
 
 #AlertPopUp .alertSoftButtons {


### PR DESCRIPTION
Fixes #536 

This PR is **ready** for review.

### Testing Plan
Send AlertManeuver without softbuttons, popup should appear with a centered "Close" button

### Summary
Center close button when present in AlertManeuver popup

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
