### PR TITLE
Fixed uncaught ReferenceError SetDisplayLayout(displayLayout = DEFAULT)

### DIFF
--- a/ffw/UIRPC.js
+++ b/ffw/UIRPC.js
@@ -492,14 +492,14 @@ FFW.UI = FFW.RPCObserver.create(
               Em.Logger.log('FFW.' + request.method + 'Response');
               var displayLayout = request.params.displayLayout;
               if (displayLayout === "DEFAULT") {
-                for (var i=0; i<model.appType.length; i++) {
-                  if (model.appType[i] === "NAVIGATION") {
-                    displayLayout = NAV_FULLSCREEN_MAP;
+                for (var i=0; i<SDL.SDLController.model.appType.length; i++) {
+                  if (SDL.SDLController.model.appType[i] === "NAVIGATION") {
+                    displayLayout = this.NAV_FULLSCREEN_MAP;
                     break;
                   }
                 }
                 if (displayLayout != "NAV_FULLSCREEN_MAP") {
-                  if (model.isMedia === true) {
+                  if (SDL.SDLController.model.isMedia === true) {
                     displayLayout = "MEDIA"
                   } else {
                     displayLayout = "NON-MEDIA"

--- a/ffw/UIRPC.js
+++ b/ffw/UIRPC.js
@@ -494,7 +494,7 @@ FFW.UI = FFW.RPCObserver.create(
               if (displayLayout === "DEFAULT") {
                 for (var i=0; i<SDL.SDLController.model.appType.length; i++) {
                   if (SDL.SDLController.model.appType[i] === "NAVIGATION") {
-                    displayLayout = this.NAV_FULLSCREEN_MAP;
+                    displayLayout = "NAV_FULLSCREEN_MAP";
                     break;
                   }
                 }


### PR DESCRIPTION
Fixes [#534 ](https://github.com/smartdevicelink/sdl_hmi/issues/534)

This PR is **ready** for review.

### Testing Plan
Mobile application is registered and activated, mobile app requests SetDisplayLayout (displayLayout = DEFAULT), app requests SetDisplayLayout(displayLayout = DEFAULT), observe result: 
HMI responds with: {"success":true,"resultCode":"SUCCESS"}, HMI applies appropriate template .


### Summary
Fixed uncaught ReferenceError during processing SetDisplayLayout(displayLayout = DEFAULT).

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
