### PR TITLE
remove unnecessary MenuList setMode

### DIFF
--- a/app/controlls/MenuList.js
+++ b/app/controlls/MenuList.js
@@ -83,6 +83,16 @@ SDL.MenuList = Em.ContainerView.extend({
     );
   },
 
+  /** Method setting up display mode for correspond components */
+  setMode: function(mode){
+    var items = this.get('content.childViews');
+
+    for (var i = 0; i < items.length; ++i) {
+      var button = items[i];
+      button.setMode(mode);
+    }
+  },
+
   classNames: [
     'ffw_list_menu'
   ],

--- a/app/controlls/MenuList.js
+++ b/app/controlls/MenuList.js
@@ -50,12 +50,7 @@ SDL.MenuList = Em.ContainerView.extend({
                    text: buttons[i].text,
                    icon: buttons[i].image ? buttons[i].image.value : '',
                    groupName: 'AlertPopUp',
-                   classNameBindings: ['isHighlighted:isHighlighted',
-                   'getCurrentDisplayModeClass'],
-                   getCurrentDisplayModeClass: function() {
-                    return SDL.ControlButtons.getCurrentDisplayModeClass(
-                      SDL.ControlButtons.imageMode.selection);
-                  }.property('SDL.ControlButtons.imageMode.selection'),
+                   classNameBindings: ['isHighlighted:isHighlighted'],
                    isHighlighted: buttons[i].isHighlighted ? true : false,
                    softButtonID: buttons[i].softButtonID,
                    systemAction: buttons[i].systemAction,

--- a/app/controlls/MenuList.js
+++ b/app/controlls/MenuList.js
@@ -83,16 +83,6 @@ SDL.MenuList = Em.ContainerView.extend({
     );
   },
 
-  /** Method setting up display mode for correspond components */
-  setMode: function(mode){
-    var items = this.get('content.childViews');
-
-    for (var i = 0; i < items.length; ++i) {
-      var button = items[i];
-      button.setMode(mode);
-    }
-  },
-
   classNames: [
     'ffw_list_menu'
   ],

--- a/app/view/mediaView.js
+++ b/app/view/mediaView.js
@@ -68,7 +68,6 @@ SDL.MediaView = Em.ContainerView.create(
 
       this.optionsMenu.preferencesButton.optionsButton.setMode(SDL.SDLModel.data.imageMode);
 
-      this.sdlView.innerMenu.setMode(SDL.SDLModel.data.imageMode);
       this.sdlView.controlls.Controls.PrevTrackButton.setMode(SDL.SDLModel.data.imageMode);
       this.sdlView.controlls.Controls.PlayButton.setMode(SDL.SDLModel.data.imageMode);
       this.sdlView.controlls.Controls.NextTrackButton.setMode(SDL.SDLModel.data.imageMode);

--- a/app/view/mediaView.js
+++ b/app/view/mediaView.js
@@ -68,6 +68,7 @@ SDL.MediaView = Em.ContainerView.create(
 
       this.optionsMenu.preferencesButton.optionsButton.setMode(SDL.SDLModel.data.imageMode);
 
+      this.sdlView.innerMenu.setMode(SDL.SDLModel.data.imageMode);
       this.sdlView.controlls.Controls.PrevTrackButton.setMode(SDL.SDLModel.data.imageMode);
       this.sdlView.controlls.Controls.PlayButton.setMode(SDL.SDLModel.data.imageMode);
       this.sdlView.controlls.Controls.NextTrackButton.setMode(SDL.SDLModel.data.imageMode);

--- a/app/view/sdl/shared/scrollableMessage.js
+++ b/app/view/sdl/shared/scrollableMessage.js
@@ -55,6 +55,9 @@ SDL.ScrollableMessage = SDL.SDLAbstractView.create(
     childViews: [
       'backButton', 'captionText', 'softButtons', 'listOfCommands'
     ],
+    imageModeChanged: function() {
+      this.get('softButtons').setMode(SDL.SDLModel.data.imageMode);
+    }.observes('SDL.SDLModel.data.imageMode'),
     /**
      * Deactivate View
      *


### PR DESCRIPTION
Implements/Fixes https://github.com/smartdevicelink/sdl_hmi/issues/317

This PR is **ready** for review.

### Testing Plan
Reproduction steps from issue, manual tests with display Mode

### Summary
Remove unnecessary setMode from MenuList, the childView buttons update by displayMode without this function and setMode can cause a console error when the children are being updated.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
