### PR TITLE
Fixed response for DeleteCommand request

### DIFF
--- a/app/model/sdl/Abstract/AppModel.js
+++ b/app/model/sdl/Abstract/AppModel.js
@@ -832,9 +832,11 @@ SDL.ABSAppModel = Em.Object.extend(
       }
 
       if (menuID in commandsList) {
-        delete(commandsList[menuID]);
-        SDL.SDLController.onDeleteSubMenu(menuID);
-        SDL.OptionsView.commands.refreshItems();
+        if (commandsList[menuID].length == 0) {
+            delete(commandsList[menuID]);
+            SDL.SDLController.onDeleteSubMenu(menuID);
+            SDL.OptionsView.commands.refreshItems()
+        }
         return SDL.SDLModel.data.resultCode.SUCCESS;
       }
 


### PR DESCRIPTION
Fixes [#569](https://github.com/smartdevicelink/sdl_hmi/issues/569)

This PR is **ready** for review.

### Testing Plan

SDL and HMI are started;mobile app is registered and activated;
SubMenu item is added
AddSubMenu("menuID":1, "menuName":"Submenu Name 1")
Nested submenu item are added (each submenu is nested in the previous submenu)
Send AddSubMenu(parentID=1, "menuID":2, "menuName":"Submenu Name 2")
Send AddSubMenu(parentID=2, "menuID":3, "menuName":"Submenu Name 3")
Send AddSubMenu(parentID=3, "menuID":4, "menuName":"Submenu Name 4")
Added AddCommand item to nested SubMenu
Send AddCommand("menuParams: { "parentID:4, "menuName":"Item to Add 1", "position":0)
Delete submenu item (item is menu-tree branch)
Send DeleteSubMenu("menuID":4)
Observe expected 'HMI→SDL: UI.DeleteCommand (resultCode = SUCCESS)'

### Summary
Fixed response from HMI to SDL on DeleteCommand request when delete the top level submenu.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
