### PR TITLE
Fixed HMI sends OnInteriorVehicleData notification without default module ID

### DIFF
--- a/app/controller/sdl/RCModulesController.js
+++ b/app/controller/sdl/RCModulesController.js
@@ -741,6 +741,7 @@ SDL.RCModulesController = Em.Object.create({
     updateCurrentModels: function(location_name) {
         this.set('currentClimateModel', this.getCoveringModuleModel('CLIMATE', location_name));
         this.set('currentAudioModel', this.getCoveringModuleModel('AUDIO', location_name));
+        this.set('currentSeatModel', this.getCoveringModuleModel('SEAT', location_name));
         this.set('currentRadioModel', this.getCoveringModuleModel('RADIO', location_name));
         this.set('currentHMISettingsModel', this.getCoveringModuleModel('HMI_SETTINGS', location_name));
         this.set('currentLightModel', this.getCoveringModuleModel('LIGHT', location_name));


### PR DESCRIPTION
Fixes [#582](https://github.com/smartdevicelink/sdl_hmi/issues/582)

This PR is **[ready]** for review.

### Testing Plan

SDL and HMI are started
On HMI go to -> "SETTING" -> "SEAT"
Update "heatingEnabled" on HMI and press 'Set' button
Default ID "d38e4a05-b17c-28e3-9d38-e4a05b17c28e" is observed on HMI
HMI sends OnInteriorVehicleData notification with 'module ID':"d38e4a05-b17c-28e3-9d38-e4a05b17c28e"

### Summary
Fixed function 'updateCurrentModels' updating current models according to a newly selected module.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
