### PR TITLE
scrollable reply success on default action and steal focus

### DIFF
--- a/app/controller/sdl/Abstract/Controller.js
+++ b/app/controller/sdl/Abstract/Controller.js
@@ -614,7 +614,7 @@ SDL.SDLController = Em.Object.extend(
         }
         case 'ScrollableMessage':
         {
-          SDL.ScrollableMessage.deactivate(true);
+          SDL.ScrollableMessage.deactivate();
           break;
         }
       }
@@ -661,7 +661,7 @@ SDL.SDLController = Em.Object.extend(
         }
         case 'ScrollableMessage':
         {
-          SDL.ScrollableMessage.deactivate(true);
+          SDL.ScrollableMessage.deactivate();
           this.onActivateSDLApp(element);
           break;
         }

--- a/app/model/sdl/Abstract/Model.js
+++ b/app/model/sdl/Abstract/Model.js
@@ -1053,7 +1053,7 @@ SDL.SDLModel = Em.Object.extend({
         );
         SDL.ResetTimeoutPopUp.addRpc(
           request,
-          () => {SDL.ScrollableMessage.deactivate();},
+          () => {SDL.ScrollableMessage.deactivate(false, true);},
           SDL.ScrollableMessage.resetTimeoutCallback,
           request.params.timeout
         );

--- a/app/view/sdl/shared/scrollableMessage.js
+++ b/app/view/sdl/shared/scrollableMessage.js
@@ -62,14 +62,16 @@ SDL.ScrollableMessage = SDL.SDLAbstractView.create(
      * @param {Object} ABORTED Parameter to indicate status for
      *            UI.ScrollableMessageResponse
      */
-    deactivate: function(ABORTED) {
+    deactivate: function(ABORTED, timeout=false) {
       this.set('endTime', null);
       this.set('active', false);
       this.softButtons.set('page', 0);
+      if (timeout === false) {
+        SDL.ResetTimeoutPopUp.stopRpcProcessing('UI.ScrollableMessage');
+      }
 
       let calculate_result_code = function(areAllImagesValid) {
         if (ABORTED) {
-          SDL.ResetTimeoutPopUp.stopRpcProcessing('UI.ScrollableMessage');
           return SDL.SDLModel.data.resultCode.ABORTED;
         }
 


### PR DESCRIPTION
Implements/Fixes https://github.com/smartdevicelink/sdl_hmi/issues/587

This PR is **ready** for review.

### Testing Plan
described in issue

### Summary
- Change response of ScrollableMessage on both DEFAULT_ACTION and STEAL_FOCUS from ABORTED to SUCCESS
- Adjust when to call `ResetTimeoutPopUp.stopRpcProcessing('UI.ScrollableMessage');`, so it will be called also on DEFAULT_ACTION and ABORTED

(this call is unnecessary in timeout case because timeout call is from ResetTimeoutPopUp when it has finished processing this RPC and behavior is already in effect)

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
