### PR TITLE
Fixed HMI shows identical navigation buttons for all registered apps

### DIFF
--- a/app/model/sdl/Abstract/AppModel.js
+++ b/app/model/sdl/Abstract/AppModel.js
@@ -63,7 +63,7 @@ SDL.ABSAppModel = Em.Object.extend(
      * navigation subscription buttons.
      * Depends on BC.SubscribeButton request.
      */    
-    NAV_BUTTONS: {
+    NAV_BUTTONS_INITIAL: {
         NAV_CENTER_LOCATION: {
           subscribed: false,
           text: "Center"

--- a/app/model/sdl/MediaModel.js
+++ b/app/model/sdl/MediaModel.js
@@ -42,6 +42,7 @@ SDL.SDLMediaModel = SDL.ABSAppModel.extend({
     for (var key in SDL.SDLVehicleInfoModel.vehicleData) {
       subscribeVIData[key] = false;
     }
+    this.NAV_BUTTONS = SDL.deepCopy(this.NAV_BUTTONS_INITIAL);
 
     this.set('subscribedData', subscribeVIData);
 

--- a/app/model/sdl/NonMediaModel.js
+++ b/app/model/sdl/NonMediaModel.js
@@ -43,6 +43,8 @@ SDL.SDLNonMediaModel = SDL.ABSAppModel.extend({
       subscribeVIData[key] = false;
     }
 
+    this.NAV_BUTTONS = SDL.deepCopy(this.NAV_BUTTONS_INITIAL);
+
     this.set('subscribedData', subscribeVIData);
 
     // init properties here


### PR DESCRIPTION
Fixes #578 

This PR is **ready** for review.

### Testing Plan
**Precondition:**
    1. SDL and HMI are started
    2. Mobile device connected
    3. Navigation app1 and navigation app2
    4. Mobile app1 is activated

**Steps to reproduce:**
1. Mobile app requests SubscribeButton for of navigation buttons (e.g. NAV_ZOOM_IN, NAV_ZOOM_OUT)
2. Go to `Nav Buttons` on app1 HMI screen
3. Go to `Nav Buttons` on app2 HMI screen


### Summary
Looks like all application models used a reference to the same instance of the map `NAV_BUTTONS` so in case if one navigation app updates its subscriptions, the same changes would be applied to all other navigation apps and vice versa.
To fix that, each application now makes a copy of the initial map instead of getting a reference to it.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
