### PR TITLE
Fixed HMI processes RPC as unsuccessful in case of custom UNSUPPORTED_RESOURCE result code

### DIFF
--- a/ffw/RPCHelper.js
+++ b/ffw/RPCHelper.js
@@ -113,7 +113,8 @@ FFW.RPCHelper = Em.Object.create(
         SDL.SDLModel.data.resultCode.WRONG_LANGUAGE,
         SDL.SDLModel.data.resultCode.RETRY,
         SDL.SDLModel.data.resultCode.SAVED,
-        SDL.SDLModel.data.resultCode.TRUNCATED_DATA
+        SDL.SDLModel.data.resultCode.TRUNCATED_DATA,
+        SDL.SDLModel.data.resultCode.UNSUPPORTED_RESOURCE
       ].includes(resultCode);
     },
 


### PR DESCRIPTION
Fixes [#577](https://github.com/smartdevicelink/sdl_hmi/issues/577)

This PR is **ready** for review.

### Testing Plan

- SDL and HMI are started;
- Mobile app is registered and activated:
- Go to Main HMI setting-> RPC Control ->registered app name;
- Set UNSUPPORTED_RESOURCE result code for some RCP(e.g. AddSubMenu, AddCommand);
- Mobile app requests RPC (AddSubMenu, AddCommand) that has custom UNSUPPORTED_RESOURCE result code on HMI;

Observe HMI adds requested item and responds with UNSUPPORTED_RESOURCE result code.

### Summary
Fixed HMI processes RPC as unsuccessful in case of custom UNSUPPORTED_RESOURCE result code.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
