### PR TITLE
set alert priority on AlertActive

### DIFF
--- a/app/view/sdl/AlertPopUp.js
+++ b/app/view/sdl/AlertPopUp.js
@@ -273,9 +273,9 @@ SDL.AlertPopUp = Em.ContainerView.create(
       this.set('isTemplateAlertIcon', message.params.alertIcon && message.params.alertIcon.isTemplate === true);
       this.addSoftButtons(message.params.softButtons, message.params.appID);
       this.set('progressIndicator', message.params.progressIndicator);
-      this.set(
-        'appName', SDL.SDLController.getApplicationModel(message.params.appID).appName
-      );
+      var appModel = SDL.SDLController.getApplicationModel(message.params.appID);
+      this.set('appName', appModel.appName);
+      this.set('priority', appModel.priority);
       for (var i = 0; i < message.params.alertStrings.length; i++) {
         switch (message.params.alertStrings[i].fieldName) {
           case 'alertText1':


### PR DESCRIPTION
This PR is **ready** for review.

### Summary
This issue is a regression from 0189. The Alert priority is not set, therefore without this PR alerts cannot be overridden by a higher priority app.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
