### PR TITLE
Fixed TurnList items appear on top of one another

### DIFF
--- a/app/view/sdl/shared/tbtTurnList.js
+++ b/app/view/sdl/shared/tbtTurnList.js
@@ -93,6 +93,7 @@ SDL.TBTTurnList = SDL.SDLAbstractView.create(
               content: turnListArray[i].navigationText ?
                 turnListArray[i].navigationText.fieldText : '',
               classNames:turnListArray[i].turnIcon ? turnListArray[i].turnIcon.isTemplate ? ['list-item','ico-overlay'] : 'list-item':'' ,
+              classNames:turnListArray[i].navigationText ? turnListArray[i].navigationText.isTemplate ? ['list-item','ico-overlay'] : 'list-item':'' ,
               classNameBindings: 'getCurrentDisplayModeClass',
               getCurrentDisplayModeClass: function() {
                 return SDL.ControlButtons.getCurrentDisplayModeClass(


### PR DESCRIPTION
Fixes [#483](https://github.com/smartdevicelink/sdl_hmi/issues/483)

This PR is **ready** for review.

### Testing Plan
Navigation-1" group is assigned to mobile app;
SDL and HMI are started;
Navigation app is registered and activated;
ShowConstantTBT is requested successfully;
Mobile app requests UpdateTurnList with turn items without images;

Observe: HMI responds with SUCCESS to Navigation.UpdateTurnList;
                HMI shows the list of added turn items in Turn List


### Summary
Fixed TurnList items appear on top of one another.

### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
