### PR TITLE
Fix/hmi doesnt update timeout prompt

### DIFF
--- a/app/controller/sdl/Abstract/Controller.js
+++ b/app/controller/sdl/Abstract/Controller.js
@@ -792,7 +792,7 @@ SDL.SDLController = Em.Object.extend(
       SDL.SDLModel.data.set('interactionData.vrHelpTitle', null);
       SDL.SDLModel.data.set('interactionData.vrHelp', null);
       clearTimeout(SDL.SDLModel.promptTimeout);
-      SDL.SDLModel.set('timeoutPromprtCallback', undefined);
+      SDL.SDLModel.set('timeoutPromptCallback', undefined);
       SDL.SDLController.getApplicationModel(
         appID
       ).activeRequests.uiPerformInteraction = null;

--- a/app/model/sdl/Abstract/Model.js
+++ b/app/model/sdl/Abstract/Model.js
@@ -68,7 +68,7 @@ SDL.SDLModel = Em.Object.extend({
   subscribedData: {},
 
   applicationStatusBar: '',
-  timeoutPromprtCallback: undefined,
+  timeoutPromptCallback: undefined,
   promptTimeout: undefined,
 
   updateStatusBar: function() {
@@ -1492,7 +1492,7 @@ SDL.SDLModel = Em.Object.extend({
         (timeout) => {
           SDL.InteractionChoicesView.set('timeout', timeout);
           clearTimeout(SDL.SDLModel.promptTimeout);
-          SDL.SDLModel.promptTimeout = setTimeout(SDL.SDLModel.timeoutPromprtCallback, timeout - 2000);
+          SDL.SDLModel.promptTimeout = setTimeout(SDL.SDLModel.timeoutPromptCallback, timeout - 2000);
         },
         message.params.timeout,
         !SDL.SDLModel.data.VRActive
@@ -1533,7 +1533,7 @@ SDL.SDLModel = Em.Object.extend({
       return;
     }
 
-    SDL.SDLModel.timeoutPromprtCallback = () => {
+    SDL.SDLModel.timeoutPromptCallback = () => {
       if (SDL.SDLModel.data.vrActiveRequests.vrPerformInteraction) { // If VR PerformInteraction session is still active
         SDL.SDLModel.VRonPrompt(message.params.timeoutPrompt);
       } else if (!message.params.grammarID &&
@@ -1543,7 +1543,7 @@ SDL.SDLModel = Em.Object.extend({
         SDL.SDLModel.VRonPrompt(message.params.timeoutPrompt);
       }
     }
-    SDL.SDLModel.promptTimeout = setTimeout(SDL.SDLModel.timeoutPromprtCallback,
+    SDL.SDLModel.promptTimeout = setTimeout(SDL.SDLModel.timeoutPromptCallback,
        message.params.timeout - 2000); //Magic numer is a platform depended HMI behavior: -2 seconds for timeout prompt
 
     SDL.SDLModel.VRonPrompt(message.params.initialPrompt);


### PR DESCRIPTION
Fixes [#599](https://github.com/smartdevicelink/sdl_hmi/issues/599)

This PR is **ready]** for review.

### Testing Plan
Manual testing

### Summary
The problem was requesting UI.PI after resetting the timeout. The timeout request did not update the timer.
Added an additional variable to save the timeout for the timeout prompt and the ability to reset it

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
