### PR TITLE
Fixed issue when HMI does not send Speak response by softButton press within Alert and SubtitleAlert RPCs

### DIFF
--- a/app/view/sdl/AlertPopUp.js
+++ b/app/view/sdl/AlertPopUp.js
@@ -153,7 +153,10 @@ SDL.AlertPopUp = Em.ContainerView.create(
       this.set('content1', '');
       this.set('content2', '');
       this.set('content3', '');
-      if(reason !== 'timeout') SDL.ResetTimeoutPopUp.stopRpcProcessing('UI.Alert');
+      if(reason !== 'timeout') {
+          SDL.SDLController.TTSResponseHandler();
+          SDL.ResetTimeoutPopUp.stopRpcProcessing('UI.Alert');
+      }
       if ((reason == 'timeout' &&
         this.softbuttons.buttons._childViews.length > 0) ||
         reason === 'ABORTED') {

--- a/app/view/sdl/SubtleAlertPopUp.js
+++ b/app/view/sdl/SubtleAlertPopUp.js
@@ -138,7 +138,10 @@ SDL.SubtleAlertPopUp = Em.ContainerView.create(
             this.set('endTime', null);
             this.set('content1', '');
             this.set('content2', '');
-            if(reason !== 'timeout') SDL.ResetTimeoutPopUp.stopRpcProcessing('UI.SubtleAlert');
+            if(reason !== 'timeout') {
+                SDL.SDLController.TTSResponseHandler();
+                SDL.ResetTimeoutPopUp.stopRpcProcessing('UI.SubtleAlert');
+            }
             if ((reason == 'timeout' &&
                 this.softbuttons.buttons._childViews.length > 0) ||
                 reason === 'ABORTED') {


### PR DESCRIPTION
Implements/Fixes [#598](https://github.com/smartdevicelink/sdl_hmi/issues/598)

This PR is **ready** for review.

### Testing Plan
Manual testing

### Summary
Added call TTSResponseHandler for the Alert and SubtleAlert in deactivate method if the reason is not timeout

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
