### PR TITLE
Fixed get ivd consent doesnt close reset timeout popup

### DIFF
--- a/app/controller/sdl/RController.js
+++ b/app/controller/sdl/RController.js
@@ -546,6 +546,7 @@ SDL.RController = SDL.SDLController.extend(
           function(result) {
             allowed.push(result);
             if(allowed.length == moduleIds.length) {
+              SDL.ResetTimeoutPopUp.stopRpcProcessing(request.method);
               FFW.RC.GetInteriorVehicleDataConsentResponse(request, allowed);
             }
           }


### PR DESCRIPTION
Fixes [#611](https://github.com/smartdevicelink/sdl_hmi/issues/611)

This PR is **ready** for review.

### Testing Plan
Manual testing

### Summary
Added `stopRpcProcessing` method call of the `ResetTimeoutPopUp` after pressing **OK** button of Get IVD consent pop-up

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
