### PR TITLE
Fixed issue: HMI does not reject Navi.AlertManeuver request in case another AlertManeuver request is in progress

### DIFF
--- a/app/controller/sdl/RController.js
+++ b/app/controller/sdl/RController.js
@@ -546,6 +546,7 @@ SDL.RController = SDL.SDLController.extend(
           function(result) {
             allowed.push(result);
             if(allowed.length == moduleIds.length) {
+              SDL.ResetTimeoutPopUp.stopRpcProcessing(request.method);
               FFW.RC.GetInteriorVehicleDataConsentResponse(request, allowed);
             }
           }


### PR DESCRIPTION
Fixes [#619](https://github.com/smartdevicelink/sdl_hmi/issues/619)

This PR is **ready** for review.

### Testing Plan
Manual testing

### Summary
Added check AlertManeuver is active

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
