### PR TITLE
Cannot read property 'removeClass' of undefined by switching of Display mode and during active PerformInteraction

### DIFF
--- a/app/controller/sdl/RController.js
+++ b/app/controller/sdl/RController.js
@@ -546,6 +546,7 @@ SDL.RController = SDL.SDLController.extend(
           function(result) {
             allowed.push(result);
             if(allowed.length == moduleIds.length) {
+              SDL.ResetTimeoutPopUp.stopRpcProcessing(request.method);
               FFW.RC.GetInteriorVehicleDataConsentResponse(request, allowed);
             }
           }


### PR DESCRIPTION
Implements/Fixes [#610](https://github.com/smartdevicelink/sdl_hmi/issues/610)

This PR is **ready** for review.

### Testing Plan
Manualt testing

### Summary
The childviews of naviChoices container were shifted but not destroyed. It kept triggering events like display mode change for the shifted but not destroyed elements. Added destroy method call for those elements after shifting them from container.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
