### PR TITLE
Fix VR pop-up overlaps the pop-up for timeout resetting during VR.PerfromInteraction

### DIFF
--- a/css/general.css
+++ b/css/general.css
@@ -377,7 +377,7 @@ button.next-home {
 }
 
 #ResetTimeoutPopUp {
-    left: 1450px;
+    left: 1500px;
     width: 302px;
     height: 147px;
     top: 10px;


### PR DESCRIPTION
Implements/Fixes [#622](https://github.com/smartdevicelink/sdl_hmi/issues/622)

This PR is **ready** for review.

### Testing Plan
Manual testing

### Summary
ResetTimeoutPopUp moved `right`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
