### PR TITLE
Fix/subtle aler not closed on touch outside

### DIFF
--- a/app/view/sdl/SubtleAlertPopUp.js
+++ b/app/view/sdl/SubtleAlertPopUp.js
@@ -165,6 +165,8 @@ SDL.SubtleAlertPopUp = Em.ContainerView.create(
                 SDL.SDLController.onSystemContextChange(app.appID, widget.windowID);
               });
             });
+
+            window.removeEventListener('click', this.click);
         },
         /**
          * Container for softbuttons
@@ -259,6 +261,8 @@ SDL.SubtleAlertPopUp = Em.ContainerView.create(
                 message.params.duration || this.defaultTimeout
             )
             SDL.ResetTimeoutPopUp.ActivatePopUp();
+
+            window.addEventListener('click', this.click);
         },
 
         /*


### PR DESCRIPTION
Implements/Fixes [#624](https://github.com/smartdevicelink/sdl_hmi/issues/624)

This PR is **ready** for review.

### Testing Plan
Manual testing

### Summary
Added `window.eventlistener` for subtleAlertPopUp

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
