### PR TITLE
Fix/doesnt wait timeout on button reset timeout pressed during subtlealert

### DIFF
--- a/app/view/sdl/SubtleAlertPopUp.js
+++ b/app/view/sdl/SubtleAlertPopUp.js
@@ -59,14 +59,6 @@ SDL.SubtleAlertPopUp = Em.ContainerView.create(
         reason: '',
         message: undefined,
         click(event) {
-            const path = event.path;
-            for(const pathElement of path) {
-                if ('className' in pathElement
-                    && typeof pathElement.className === 'string'
-                    && pathElement.className.match(/resetTimeoutButton|ResetTimeoutPopUp/)) {
-                        return;
-                    }
-            }
             if (document.getElementById('SubtleAlertPopUp').contains(event.target)){
                 var buttonsDiv = document.getElementById('subtleAlertSoftButtons');
                 for (var button of buttonsDiv.childNodes) {
@@ -78,7 +70,8 @@ SDL.SubtleAlertPopUp = Em.ContainerView.create(
                 this.deactivate();
                 SDL.SDLController.onActivateSDLApp({ appID: SDL.SubtleAlertPopUp.appID });
                 SDL.SDLController.onSubtleAlertPressed(SDL.SubtleAlertPopUp.appID);
-            } else{
+            } else if(!document.getElementById('right_view').contains(event.target)
+            && !document.getElementById('ResetTimeoutPopUp').contains(event.target)) {
                 SDL.SubtleAlertPopUp.deactivate();
             }
         },


### PR DESCRIPTION
Implements/Fixes [#631](https://github.com/smartdevicelink/sdl_hmi/issues/631)

This PR is **ready** for review.

### Testing Plan
Manual testing

### Summary
Added check that the click event was triggered over `ResetTimeoutPopUp` and over `ResetTimeoutButton` to the `SubleAlertPopUp` in `click` method.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
