### PR TITLE
Changed messagecode for ActivateApp for revoked app

### DIFF
--- a/ffw/BasicCommunicationRPC.js
+++ b/ffw/BasicCommunicationRPC.js
@@ -339,7 +339,7 @@ FFW.BasicCommunication = FFW.RPCObserver
               FFW.BasicCommunication.GetUserFriendlyMessage(
                 SDL.SettingsController.simpleParseUserFriendlyMessageData,
                 appID,
-                ['AppUnsupported']
+                ['AppUnauthorized']
               );
             } else {
               SDL.SDLController.getApplicationModel(appID)


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/2795

This PR is **ready** for review.

### Testing Plan
1. Register and activate app1
2. Set the app1 permissions to null using PTU
3. Make sure app1 is deactivated
4. Try to activate app1 one more time

**Expected behavior:**
HMI should use friendly messages for the `AppUnauthorized` code

### Summary
A message with AppUnauthorized code is more obvious for users when the application is revoked.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
