### PR TITLE
Fixed issue: Does not hide the "OK"/PLAY_PAUSE button after successful unsubscription

### DIFF
--- a/app/view/media/sdl/controllsView.js
+++ b/app/view/media/sdl/controllsView.js
@@ -105,7 +105,6 @@ SDL.SDLMediaControlls = Em.ContainerView.create(
               'bc-item-big',
               'playcd'
             ],
-            //classNameBindings: 'SDL.SDLController.model.PLAY_PAUSE::unsubscribed',
             presetName: 'PLAY_PAUSE',
             classNameBindings: 'SDL.SDLController.model.PLAY_PAUSE::unsubscribed',
             textBinding: 'SDL.SDLController.model.stopIndicator',

--- a/app/view/media/sdl/controllsView.js
+++ b/app/view/media/sdl/controllsView.js
@@ -107,6 +107,7 @@ SDL.SDLMediaControlls = Em.ContainerView.create(
             ],
             //classNameBindings: 'SDL.SDLController.model.PLAY_PAUSE::unsubscribed',
             presetName: 'PLAY_PAUSE',
+            classNameBindings: 'SDL.SDLController.model.PLAY_PAUSE::unsubscribed',
             textBinding: 'SDL.SDLController.model.stopIndicator',
             actionUp: function() {
               SDL.SDLController.onSoftButtonOkActionUp(this.presetName);


### PR DESCRIPTION
Implements/Fixes [#628](https://github.com/smartdevicelink/sdl_hmi/issues/628)

This PR is **ready** for review.

### Testing Plan
Manualt testing

### Summary
Added PLAY_PAUSE button subscription binding

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
