### PR TITLE
Fixed uncaught TypeError: Cannot read properties of null (reading 'hasOwnProperty') on 'DELETE' button

### DIFF
--- a/app/model/sdl/Abstract/Model.js
+++ b/app/model/sdl/Abstract/Model.js
@@ -173,9 +173,9 @@ SDL.SDLModel = Em.Object.extend({
 
         if (event.originalEvent.changedTouches && (
           event.originalEvent.changedTouches[i].pageX >
-          SDL.SDLVehicleInfoModel.vehicleData.displayResolution.width ||
+          SDL.SDLVehicleInfoModel.displayResolution.width ||
           event.originalEvent.changedTouches[i].pageY >
-          SDL.SDLVehicleInfoModel.vehicleData.displayResolution.height)) {
+          SDL.SDLVehicleInfoModel.displayResolution.height)) {
           return;
         }
 

--- a/app/model/sdl/VehicleInfoModel.js
+++ b/app/model/sdl/VehicleInfoModel.js
@@ -332,10 +332,6 @@ SDL.SDLVehicleInfoModel = Em.Object.create(
         'rearRecommended': 2.2E0
       },
       'cloudAppVehicleID': 'SDLVehicleNo123',
-      'displayResolution': {
-         'width': 800,
-         'height': 480
-      },
       'climateData': {
         'externalTemperature': {
           'unit': 'FAHRENHEIT',
@@ -363,6 +359,12 @@ SDL.SDLVehicleInfoModel = Em.Object.create(
       // 'satRadioESN': '165165650',
       // 'rainSensor': 165165650,
     },
+
+    'displayResolution': {
+         'width': 800,
+         'height': 480
+      },
+
     /**
      * Method to set selected state of vehicle transmission to vehicleData
      */


### PR DESCRIPTION
Fixes [#630 ](https://github.com/smartdevicelink/sdl_hmi/issues/630)

This PR is **ready** for review.

### Testing Plan
SDL and HMI are started. On "HMI" go to ->"Vehicle Info" -> "Edit Vehicle Data" -> Press 'Delete' button, observe: <Vehicle_Data> is deleted on HMI successfully.

### Summary
The 'displayResolution' parameter was moved from 'vehicleData' in file VehicleInfoModel.js.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
