### PR TITLE
Fixed issue: HMI does not apply Display mode to the VR list

### DIFF
--- a/app/view/sdl/VRPopUp.js
+++ b/app/view/sdl/VRPopUp.js
@@ -85,7 +85,11 @@ SDL.VRPopUp = Em.ContainerView.create(
                 commandID: cmdID,
                 text: vrCommands[i],
                 classNames: 'list-item',
-                templateName: 'text'
+                templateName: 'text',
+                classNameBindings: ['getCurrentDisplayModeClass'],
+                getCurrentDisplayModeClass: function() {
+                  return SDL.ControlButtons.getCurrentDisplayModeClass();
+                }.property('SDL.ControlButtons.imageMode.selection')
               }
             )
           );
@@ -120,9 +124,12 @@ SDL.VRPopUp = Em.ContainerView.create(
                     return true;
                   }
                 }.property('SDL.SDLModel.data.performInteractionSession'),
-                classNameBindings: ['this.hideButtons:hide'],
+                classNameBindings: ['this.hideButtons:hide', 'getCurrentDisplayModeClass'],
                 classNames: 'list-item',
-                templateName: 'text'
+                templateName: 'text',
+                getCurrentDisplayModeClass: function() {
+                  return SDL.ControlButtons.getCurrentDisplayModeClass();
+                }.property('SDL.ControlButtons.imageMode.selection')
               }
             )
           );


### PR DESCRIPTION
Fixes [#649](https://github.com/smartdevicelink/sdl_hmi/issues/649)

This PR is **ready** for review.

### Testing Plan
Manual testing

### Summary
Added getCurrentDisplayModeClass to button creation in VRPopUp

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
