### PR TITLE
Fix/hmi updates choice list after second pi request

### DIFF
--- a/app/controller/sdl/Abstract/Controller.js
+++ b/app/controller/sdl/Abstract/Controller.js
@@ -812,6 +812,7 @@ SDL.SDLController = Em.Object.extend(
       SDL.SDLModel.data.interactionData.helpPrompt = null;
       SDL.SDLModel.data.vrActiveRequests.vrPerformInteraction = null;
       SDL.SDLModel.data.set('VRActive', false);
+      SDL.SDLModel.set('allowUIPerformInteraction', true);
     },
     /**
      * Method to sent notification for Alert

--- a/ffw/VRRPC.js
+++ b/ffw/VRRPC.js
@@ -243,13 +243,16 @@ FFW.VR = FFW.RPCObserver.create(
           }
           case 'VR.PerformInteraction':
           {
-            if(SDL.ResetTimeoutPopUp.includes(request.method)) {
-              this.sendError(
-                SDL.SDLModel.data.resultCode.REJECTED,
-                request.id,
-                request.method,
-                `${request.method} is already in progress`
-              )
+            if(SDL.ResetTimeoutPopUp.includes(request.method) ||
+              SDL.ResetTimeoutPopUp.includes('UI.PerformInteraction')) {
+              SDL.SDLModel.vrRejectedCallback = () => {
+                this.sendError(
+                  SDL.SDLModel.data.resultCode.REJECTED,
+                  request.id,
+                  request.method,
+                  `${request.method} is already in progress`
+                )
+              }
               return;
             }
             SDL.SDLModel.vrPerformInteraction(request);


### PR DESCRIPTION
Implements/Fixes [#650](https://github.com/smartdevicelink/sdl_hmi/issues/650) [#647](https://github.com/smartdevicelink/sdl_hmi/issues/647)

This PR is **ready** for review.

### Testing Plan
Manual testing

### Summary
Added flag for allow incoming UI.PI request.
Also added order of PI responses if request should be rejected on the HMI: first `UI.PI`, then `VR.PI`. The reason of ordering is that the SDL send to the HMI `ClosePopUp` request in case the second request was rejected, it will stop current `UI.PI` request. To prevent it, the order of responses was implemented.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
