### PR TITLE
Fix/uncaught type error by press phone button

### DIFF
--- a/app/view/phoneView.js
+++ b/app/view/phoneView.js
@@ -73,7 +73,7 @@ SDL.PhoneView = Em.ContainerView.create(
                 textBinding: Em.Binding
                   .oneWay('SDL.locale.label.view_phone_phone'),
                 icon: 'images/phone/ico_phone.png',
-                action: 'onDialCall',
+                action: 'onDelete',
                 target: 'SDL.PhoneController'
               }
             )

--- a/app/view/phoneView.js
+++ b/app/view/phoneView.js
@@ -73,9 +73,8 @@ SDL.PhoneView = Em.ContainerView.create(
                 textBinding: Em.Binding
                   .oneWay('SDL.locale.label.view_phone_phone'),
                 icon: 'images/phone/ico_phone.png',
-                action: 'subState',
-                target: 'SDL.PhoneController',
-                stateName: 'dialpad'
+                action: 'onDialCall',
+                target: 'SDL.PhoneController'
               }
             )
           }


### PR DESCRIPTION
Implements/Fixes [#658](https://github.com/smartdevicelink/sdl_hmi/issues/658)

This PR is **ready** for review.

### Testing Plan
Manual testing

### Summary
There was used an unexisted action subState for the Phone button.
The Phone button action was replaced with onDialCall.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
