### PR TITLE
remove PNG requirements from non template images

### DIFF
--- a/app/controller/NavigationController.js
+++ b/app/controller/NavigationController.js
@@ -582,18 +582,12 @@ SDL.NavigationController = Em.Object.create(
     validateIcons: function(request) {
       var params = request.params;
       imageList = [];
-      var nonPngCounter = 0;
 
       if(params.turnList) {
         var countList=params.turnList.length;
         for(var i = 0; i < countList; i++) {
           if(params.turnList[i].turnIcon) {
             var icon = params.turnList[i].turnIcon;
-            if(!this.isPng(icon.value)) {
-              delete params.turnList[i].turnIcon;
-              nonPngCounter++;
-              continue;
-            } 
             imageList.push(icon);
           }
         }
@@ -603,39 +597,15 @@ SDL.NavigationController = Em.Object.create(
         for(var i=0;i<countButtons;i++) {
           if(params.softButtons[i].image) {
             var icon = params.softButtons[i].image;
-            if(!this.isPng(icon.value)) {
-              delete params.softButtons[i].image;
-              nonPngCounter++;
-              continue;
-            } 
             imageList.push(icon);
           }
         }
       }
       if(params.turnIcon) {
-        if(!this.isPng(params.turnIcon.value)) {
-          delete params.turnIcon;
-          nonPngCounter++;
-        } else {
-          imageList.push(params.turnIcon);
-        }
+        imageList.push(params.turnIcon);
       } 
       if(params.nextTurnIcon) {
-        if(!this.isPng(params.nextTurnIcon.value)) {
-          delete params.nextTurnIcon;
-          nonPngCounter++;
-        } else {
-          imageList.push(params.nextTurnIcon);
-        }
-      }
-
-      if(nonPngCounter > 0) {
-        FFW.Navigation.sendNavigationResult(
-          SDL.SDLModel.data.resultCode.WARNINGS,
-          request.id,
-          request.method,
-        );
-        return;
+        imageList.push(params.nextTurnIcon);
       }
 
       var callback = function(failed, info) {

--- a/app/model/sdl/MediaModel.js
+++ b/app/model/sdl/MediaModel.js
@@ -445,18 +445,12 @@ SDL.SDLMediaModel = SDL.ABSAppModel.extend({
     }
 
     if (params.graphic != null) {
-      var image = params.graphic.value;
-      var search_offset = image.lastIndexOf('.');
-      str = '.png';
-      var isPng = image.includes(str,search_offset);
-      if (isPng) {
-        if (params.graphic.value != '') {
-          this.appInfo.set('mainImage', params.graphic.value);
-        } else {
-          this.appInfo.set('mainImage', 'images/sdl/audio_icon.jpg');
-        }
-        this.set('isTemplate', 'DYNAMIC' == params.graphic.imageType && params.graphic.isTemplate === true);
+      if (params.graphic.value != '') {
+        this.appInfo.set('mainImage', params.graphic.value);
+      } else {
+        this.appInfo.set('mainImage', 'images/sdl/audio_icon.jpg');
       }
+      this.set('isTemplate', 'DYNAMIC' == params.graphic.imageType && params.graphic.isTemplate === true);
     }
 
     if ('softButtons' in params) {


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_hmi/issues/665

This PR is **ready** for review.

### Testing Plan
Using a JPEG image in each RPC that has an Image parameter.

### Summary
Remove the requirement that images sent to the SDL HMI have the PNG extension. The browser can render many different types of images so there is no need for this requirement.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
