### PR TITLE
Fixed issue: HMI does not send videoStreaming parameter as part of UI.GetCapabilities response

### DIFF
--- a/ffw/UIRPC.js
+++ b/ffw/UIRPC.js
@@ -1045,7 +1045,8 @@ FFW.UI = FFW.RPCObserver.create(
                 ],
                 'hmiCapabilities': {
                   'navigation': true,
-                  'phoneCall': true
+                  'phoneCall': true,
+                  'videoStreaming':true
                 },
                 'systemCapabilities': SDL.systemCapabilities,
                 'code': SDL.SDLModel.data.resultCode.SUCCESS,


### PR DESCRIPTION
Implements/Fixes [#669](https://github.com/smartdevicelink/sdl_hmi/issues/669)

This PR is **[ready]** for review.

### Testing Plan
Covered by manual testing

### Summary

Add 'videoStreaming' parameter to `hmiCapabilities`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
