### PR TITLE
Add null check for vehicle data

### DIFF
--- a/app/model/sdl/VehicleInfoModel.js
+++ b/app/model/sdl/VehicleInfoModel.js
@@ -599,7 +599,7 @@ SDL.SDLVehicleInfoModel = Em.Object.create(
           key = 'clusterModes';
         }
         if (key != 'appID') {
-          if (this.vehicleData[key] != undefined) {
+          if (this.vehicleData && this.vehicleData[key] != undefined) {
             data[oldKey] = this.vehicleData[key];
           } else {
             if (!result) {


### PR DESCRIPTION
Fixes #667 

This PR is **ready** for review.

### Testing Plan
Test described in issue.

Delete entire vehicle data object in hmi, then send a getVehicleData request.



### Summary
The delete button in the sdl hmi replaces the entire object with `null`. This pr adds a null check to prevent reading a property on a null object.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
