### PR TITLE
Assume default framerate of 20 fps when it cannot be detected

### DIFF
--- a/tools/start_server.py
+++ b/tools/start_server.py
@@ -99,7 +99,7 @@ class StreamingProcessHolder:
 						print('gst-launch-1.0 souphttpsrc location=' + url + ' ! decodebin ! videoconvert ! xvimagesink sync=false')
 					return -1
 
-			StreamingProcessHolder.videoStream = ffmpeg.input(url).output(stream_endpoint, vcodec="vp8", format="webm", listen=1, multiple_requests=1).run_async(pipe_stderr=True)
+			StreamingProcessHolder.videoStream = ffmpeg.input(url, framerate='20').output(stream_endpoint, vcodec="vp8", format="webm", listen=1, multiple_requests=1).run_async(pipe_stderr=True)
 			return StreamingProcessHolder.waitForInput(StreamingProcessHolder.videoStream)
 
 		if streaming_type == 'audio':


### PR DESCRIPTION
Workaround for #685 

This PR is **ready** for review.

### Testing Plan
Test video streaming with default framerate, verify `20 fps` is present in the backend logs:

```
Input #0, h264, from 'http://127.0.0.1:5050':
  Duration: N/A, bitrate: N/A
    Stream #0:0: Video: h264 (High), yuv420p(tv, smpte170m/bt470bg/smpte170m, progressive), 800x380, 20 fps, 20 tbr, 1200k tbn, 40 tbc
```

Core version / branch / commit hash / module tested against: develop
Proxy+Test App name / version / branch / commit hash / module tested against: Java Test Suite develop

### Summary
Assume 20fps video if ffmpeg cannot detect framerate of input video

### Changelog
##### Bug Fixes
* Assume 20fps video if ffmpeg cannot detect framerate of input video

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)