### PR TITLE
Fix/Add Missing WEB_VIEW display capabilities

### DIFF
--- a/capabilities/display_capabilities.js
+++ b/capabilities/display_capabilities.js
@@ -83,6 +83,24 @@ let mediaCapabilities = {
                 "rows": 1
             },
             {
+                "name": "subtleAlertText1",
+                "characterSet": "UTF_8",
+                "width": 500,
+                "rows": 1
+            },
+            {
+                "name": "subtleAlertText2",
+                "characterSet": "UTF_8",
+                "width": 500,
+                "rows": 1
+            },
+            {
+                "name": "subtleAlertSoftButtonText",
+                "characterSet": "UTF_8",
+                "width": 500,
+                "rows": 1
+            },
+            {
                 "name": "scrollableMessageBody",
                 "characterSet": "UTF_8",
                 "width": 500,
@@ -476,6 +494,24 @@ SDL.templateCapabilities = {
                     "rows": 1
                 },
                 {
+                    "name": "subtleAlertText1",
+                    "characterSet": "UTF_8",
+                    "width": 500,
+                    "rows": 1
+                },
+                {
+                    "name": "subtleAlertText2",
+                    "characterSet": "UTF_8",
+                    "width": 500,
+                    "rows": 1
+                },
+                {
+                    "name": "subtleAlertSoftButtonText",
+                    "characterSet": "UTF_8",
+                    "width": 500,
+                    "rows": 1
+                },
+                {
                     "name": "scrollableMessageBody",
                     "characterSet": "UTF_8",
                     "width": 500,
@@ -855,6 +891,24 @@ SDL.templateCapabilities = {
                     "rows": 1
                 },
                 {
+                    "name": "subtleAlertText1",
+                    "characterSet": "UTF_8",
+                    "width": 500,
+                    "rows": 1
+                },
+                {
+                    "name": "subtleAlertText2",
+                    "characterSet": "UTF_8",
+                    "width": 500,
+                    "rows": 1
+                },
+                {
+                    "name": "subtleAlertSoftButtonText",
+                    "characterSet": "UTF_8",
+                    "width": 500,
+                    "rows": 1
+                },
+                {
                     "name": "scrollableMessageBody",
                     "characterSet": "UTF_8",
                     "width": 500,
@@ -1151,6 +1205,24 @@ SDL.templateCapabilities = {
                 },
                 {
                     "name": "alertText3",
+                    "characterSet": "UTF_8",
+                    "width": 500,
+                    "rows": 1
+                },
+                {
+                    "name": "subtleAlertText1",
+                    "characterSet": "UTF_8",
+                    "width": 500,
+                    "rows": 1
+                },
+                {
+                    "name": "subtleAlertText2",
+                    "characterSet": "UTF_8",
+                    "width": 500,
+                    "rows": 1
+                },
+                {
+                    "name": "subtleAlertSoftButtonText",
                     "characterSet": "UTF_8",
                     "width": 500,
                     "rows": 1

--- a/capabilities/display_capabilities.js
+++ b/capabilities/display_capabilities.js
@@ -1190,6 +1190,96 @@ SDL.templateCapabilities = {
                     "characterSet": "UTF_8",
                     "width": 500,
                     "rows": 1
+                },
+                {
+                    "name": "menuName",
+                    "characterSet": "UTF_8",
+                    "width": 500,
+                    "rows": 1
+                },
+                {
+                    "name": "secondaryText",
+                    "characterSet": "UTF_8",
+                    "width": 500,
+                    "rows": 1
+                },
+                {
+                    "name": "tertiaryText",
+                    "characterSet": "UTF_8",
+                    "width": 500,
+                    "rows": 1
+                },
+                {
+                    "name": "menuTitle",
+                    "characterSet": "UTF_8",
+                    "width": 15,
+                    "rows": 1
+                },
+                {
+                    "name": "navigationText1",
+                    "characterSet": "UTF_8",
+                    "width": 500,
+                    "rows": 1
+                },
+                {
+                    "name": "navigationText2",
+                    "characterSet": "UTF_8",
+                    "width": 500,
+                    "rows": 1
+                },
+                {
+                    "name": "ETA",
+                    "characterSet": "UTF_8",
+                    "width": 500,
+                    "rows": 1
+                },
+                {
+                    "name": "totalDistance",
+                    "characterSet": "UTF_8",
+                    "width": 500,
+                    "rows": 1
+                },
+                {
+                    "name": "timeToDestination",
+                    "characterSet": "UTF_8",
+                    "width": 500,
+                    "rows": 1
+                },
+                {
+                    "name": "turnText",
+                    "characterSet": "UTF_8",
+                    "width": 500,
+                    "rows": 1
+                },
+                {
+                    "name": "menuTitle",
+                    "characterSet": "UTF_8",
+                    "width": 15,
+                    "rows": 1
+                },
+                {
+                    "name": "locationName",
+                    "characterSet": "UTF_8",
+                    "width": 500,
+                    "rows": 1
+                },
+                {
+                    "name": "locationDescription",
+                    "characterSet": "UTF_8",
+                    "width": 500,
+                    "rows": 1
+                },
+                {
+                    "name": "addressLines",
+                    "characterSet": "UTF_8",
+                    "width": 500,
+                    "rows": 1
+                },
+                {
+                    "name": "phoneNumber",
+                    "characterSet": "UTF_8",
+                    "width": 500,
+                    "rows": 1
                 }
             ],
             "imageFields": [

--- a/capabilities/display_capabilities.js
+++ b/capabilities/display_capabilities.js
@@ -1210,12 +1210,6 @@ SDL.templateCapabilities = {
                     "rows": 1
                 },
                 {
-                    "name": "menuTitle",
-                    "characterSet": "UTF_8",
-                    "width": 15,
-                    "rows": 1
-                },
-                {
                     "name": "navigationText1",
                     "characterSet": "UTF_8",
                     "width": 500,
@@ -1378,7 +1372,55 @@ SDL.templateCapabilities = {
                       "resolutionWidth": 105,
                       "resolutionHeight": 65
                     }
-                  }
+                  },
+                  {
+                    "name": "vrHelpItem",
+                    "imageTypeSupported": [
+                        "GRAPHIC_BMP",
+                        "GRAPHIC_JPEG",
+                        "GRAPHIC_PNG"
+                    ],
+                    "imageResolution": {
+                        "resolutionWidth": 64,
+                        "resolutionHeight": 64
+                    }
+                },
+                {
+                    "name": "turnIcon",
+                    "imageTypeSupported": [
+                        "GRAPHIC_BMP",
+                        "GRAPHIC_JPEG",
+                        "GRAPHIC_PNG"
+                    ],
+                    "imageResolution": {
+                        "resolutionWidth": 64,
+                        "resolutionHeight": 64
+                    }
+                },
+                {
+                    "name": "showConstantTBTIcon",
+                    "imageTypeSupported": [
+                        "GRAPHIC_BMP",
+                        "GRAPHIC_JPEG",
+                        "GRAPHIC_PNG"
+                    ],
+                    "imageResolution": {
+                        "resolutionWidth": 64,
+                        "resolutionHeight": 64
+                    }
+                },
+                {
+                    "name": "showConstantTBTNextTurnIcon",
+                    "imageTypeSupported": [
+                        "GRAPHIC_BMP",
+                        "GRAPHIC_JPEG",
+                        "GRAPHIC_PNG"
+                    ],
+                    "imageResolution": {
+                        "resolutionWidth": 64,
+                        "resolutionHeight": 64
+                    }
+                }
             ],
             "graphicSupported": true,
             "imageCapabilities": ["DYNAMIC", "STATIC"],

--- a/capabilities/display_capabilities.js
+++ b/capabilities/display_capabilities.js
@@ -1130,6 +1130,166 @@ SDL.templateCapabilities = {
         "displayCapabilities": {
             "displayType": "GEN2_8_DMA",
             "displayName": "SDL_HMI",
+            "textFields": [
+                {
+                    "name": "templateTitle",
+                    "characterSet": "UTF_8",
+                    "width": 100,
+                    "rows": 1
+                },
+                {
+                    "name": "alertText1",
+                    "characterSet": "UTF_8",
+                    "width": 500,
+                    "rows": 1
+                },
+                {
+                    "name": "alertText2",
+                    "characterSet": "UTF_8",
+                    "width": 500,
+                    "rows": 1
+                },
+                {
+                    "name": "alertText3",
+                    "characterSet": "UTF_8",
+                    "width": 500,
+                    "rows": 1
+                },
+                {
+                    "name": "scrollableMessageBody",
+                    "characterSet": "UTF_8",
+                    "width": 500,
+                    "rows": 1
+                },
+                {
+                    "name": "initialInteractionText",
+                    "characterSet": "UTF_8",
+                    "width": 500,
+                    "rows": 1
+                },
+                {
+                    "name": "audioPassThruDisplayText1",
+                    "characterSet": "UTF_8",
+                    "width": 500,
+                    "rows": 1
+                },
+                {
+                    "name": "audioPassThruDisplayText2",
+                    "characterSet": "UTF_8",
+                    "width": 500,
+                    "rows": 1
+                },
+                {
+                    "name": "sliderHeader",
+                    "characterSet": "UTF_8",
+                    "width": 500,
+                    "rows": 1
+                },
+                {
+                    "name": "sliderFooter",
+                    "characterSet": "UTF_8",
+                    "width": 500,
+                    "rows": 1
+                }
+            ],
+            "imageFields": [
+                {
+                    "name": "alertIcon",
+                    "imageTypeSupported": [
+                        "GRAPHIC_BMP",
+                        "GRAPHIC_JPEG",
+                        "GRAPHIC_PNG"
+                    ],
+                    "imageResolution": {
+                        "resolutionWidth": 105,
+                        "resolutionHeight": 65
+                    }
+                },
+                {
+                    "name": "choiceImage",
+                    "imageTypeSupported": [
+                        "GRAPHIC_BMP",
+                        "GRAPHIC_JPEG",
+                        "GRAPHIC_PNG"
+                    ],
+                    "imageResolution": {
+                        "resolutionWidth": 64,
+                        "resolutionHeight": 64
+                    }
+                },
+                {
+                    "name": "choiceSecondaryImage",
+                    "imageTypeSupported": [
+                        "GRAPHIC_BMP",
+                        "GRAPHIC_JPEG",
+                        "GRAPHIC_PNG"
+                    ],
+                    "imageResolution": {
+                        "resolutionWidth": 64,
+                        "resolutionHeight": 64
+                    }
+                },
+                {
+                    "name": "cmdIcon",
+                    "imageTypeSupported": [
+                        "GRAPHIC_BMP",
+                        "GRAPHIC_JPEG",
+                        "GRAPHIC_PNG"
+                    ],
+                    "imageResolution": {
+                        "resolutionWidth": 64,
+                        "resolutionHeight": 64
+                    }
+                },
+                {
+                    "name": "subMenuIcon",
+                    "imageTypeSupported": [
+                      "GRAPHIC_BMP",
+                      "GRAPHIC_JPEG",
+                      "GRAPHIC_PNG"
+                    ],
+                    "imageResolution": {
+                      "resolutionWidth": 64,
+                      "resolutionHeight": 64
+                    }
+                },
+                {
+                    "name": "menuCommandSecondaryImage",
+                    "imageTypeSupported": [
+                      "GRAPHIC_BMP",
+                      "GRAPHIC_JPEG",
+                      "GRAPHIC_PNG"
+                    ],
+                    "imageResolution": {
+                      "resolutionWidth": 105,
+                      "resolutionHeight": 65
+                    }
+                  },
+                  {
+                    "name": "menuSubMenuSecondaryImage",
+                    "imageTypeSupported": [
+                      "GRAPHIC_BMP",
+                      "GRAPHIC_JPEG",
+                      "GRAPHIC_PNG"
+                    ],
+                    "imageResolution": {
+                      "resolutionWidth": 105,
+                      "resolutionHeight": 65
+                    }
+                  },
+                  {
+                    "name": "subtleAlertIcon",
+                    "imageTypeSupported": [
+                      "GRAPHIC_BMP",
+                      "GRAPHIC_JPEG",
+                      "GRAPHIC_PNG"
+                    ],
+                    "imageResolution": {
+                      "resolutionWidth": 105,
+                      "resolutionHeight": 65
+                    }
+                  }
+            ],
             "graphicSupported": true,
             "imageCapabilities": ["DYNAMIC", "STATIC"],
             "templatesAvailable": ["MEDIA", "NON-MEDIA", "NAV_FULLSCREEN_MAP", "WEB_VIEW"],


### PR DESCRIPTION
Fixes #686

This PR is **ready** for review.

### Testing Plan
1. Start policy server
2. Add the following entry in sdl_preloaded_pt.json

```json
            "45b2c12c-a289-4c08-b4e4-bee768bf0cf9": {
                "AppHMIType": [ "WEB_VIEW" ],
                "keep_context": false,
                "steal_focus": false,
                "priority": "NONE",
                "default_hmi": "NONE",
                "groups": ["Base-4", "WidgetSupport"],
                "hybrid_app_preference": "CLOUD",
                "enabled": false,
                "transport_type ": "WS"
            },
```

3. Change the `appStoreUrl` in Flags.js to `http://localhost:3000/api/v1/applications/store`
4. Start core and HMI
5. In the HMI, enable the "Hello Webengine3" app in the app store and activate the app
6. In the WEB_VIEW change the display layout to NON-MEDIA
7. Click on Options -> Return to WEB_VIEW

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
